### PR TITLE
[image-target-cli] Write cropped image to disk

### DIFF
--- a/apps/image-target-cli/src/apply.js
+++ b/apps/image-target-cli/src/apply.js
@@ -96,6 +96,7 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
     originalImage.toFile(path.join(folder, resources.originalImage)),
     thumbnailImage.toFile(path.join(folder, resources.thumbnailImage)),
     luminanceImage.toFile(path.join(folder, resources.luminanceImage)),
+    croppedImage.toFile(path.join(folder, resources.croppedImage)),
     fs.writeFile(dataPath, `${JSON.stringify(data, null, 2)}\n`),
   ])
 


### PR DESCRIPTION
## Context

Pointed out in https://discord.com/channels/1341900046278328383/1475660355761078447/1475689973331267634

## Testing

### Before

The `_cropped` image was not being outputted

### After


<img width="597" height="146" alt="Screenshot 2026-02-23 at 7 46 33 PM" src="https://github.com/user-attachments/assets/76e4229d-945b-4d4e-9b77-b7b6baaab5e2" />
