### PR TITLE
[image-target-processor] Handle exif rotation in source

### DIFF
--- a/apps/image-target-cli/src/apply.js
+++ b/apps/image-target-cli/src/apply.js
@@ -60,6 +60,7 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
 
   const originalImage = rawImage
     .clone()
+    .autoOrient()
     .rotate(crop.geometry.isRotated ? 90 : 0)
   const croppedImage = originalImage.clone().extract(crop.geometry)
 


### PR DESCRIPTION
## Context

Can't repro now but at one point the outputted image was flipped 180 degrees instead of 90 degrees.

TODO: Find another image it might repro on