### PR TITLE
[image-target-cli] Fix override option in test script

### DIFF
--- a/apps/image-target-cli/test/all.sh
+++ b/apps/image-target-cli/test/all.sh
@@ -4,6 +4,6 @@ set -e
 cd $(dirname "$0")/..
 
 for file in test/*.txt; do
-  echo "Running OVERWRITE_FILES=true cat $file | node ./src/index.js"
+  echo "Running cat $file | OVERWRITE_FILES=true node ./src/index.js"
   cat "$file" | OVERWRITE_FILES=true node ./src/index.js >/dev/null
 done


### PR DESCRIPTION
## Context

I think I had OVERWRITE_FILES enabled in my terminal. The way I was setting it in the script wasn't being inherited so I got "File already exists, overwrite is disabled" errors.

## Testing

`echo "$OVERWRITE_FILES"` ->  nothing

Can run `./test/all.sh` multiple times without any errors