### PR TITLE
[image-target-cli] Add npm publishing

### DIFF
--- a/apps/image-target-cli/README.md
+++ b/apps/image-target-cli/README.md
@@ -6,10 +6,7 @@ This CLI tool allows the creation of image targets in the format supported by th
 ## Usage
 
 ```
-git clone https://github.com/8thwall/8thwall.git
-cd ./8thwall/apps/image-target-cli
-npm install
-node ./src/index.js
+npx @8thwall/image-target-cli@latest
 ```
 
 You will be prompted to enter an image path, select crop, and choose a folder/image target name. You can either use a default centered crop, or choose your crop dimensions according to this diagram:

--- a/apps/image-target-cli/package-lock.json
+++ b/apps/image-target-cli/package-lock.json
@@ -1,19 +1,19 @@
 {
-  "name": "image-target-processor",
-  "version": "1.0.0",
+  "name": "@8thwall/image-target-cli",
+  "version": "1.0.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "image-target-processor",
-      "version": "1.0.0",
+      "name": "@8thwall/image-target-cli",
+      "version": "1.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^25.2.3",
-        "@types/sharp": "^0.31.1",
         "sharp": "^0.34.5"
       },
       "devDependencies": {
+        "@types/node": "^25.2.3",
+        "@types/sharp": "^0.31.1",
         "typescript": "^5.9.3"
       }
     },
@@ -470,6 +470,7 @@
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
       "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -478,6 +479,7 @@
       "version": "0.31.1",
       "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.31.1.tgz",
       "integrity": "sha512-5nWwamN9ZFHXaYEincMSuza8nNfOof8nmO+mcI+Agx1uMUk4/pQnNIcix+9rLPXzKrm1pS34+6WRDbDV0Jn7ag==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -566,7 +568,8 @@
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
     }
   }
 }

--- a/apps/image-target-cli/package.json
+++ b/apps/image-target-cli/package.json
@@ -1,11 +1,18 @@
 {
-  "name": "image-target-processor",
+  "name": "@8thwall/image-target-cli",
   "version": "1.0.0",
   "description": "Generate 8th Wall Image Target Metadata",
-  "main": "index.js",
+  "main":  "src/index.js",
+  "bin": {
+    "image-target-cli": "src/index.js"
+  },
   "type": "module",
   "scripts": {
     "test": "npx tsc -P tsconfig.json && node --test src/*.test.js"
+  },
+  "homepage": "https://8thwall.org",
+  "bugs": {
+    "url": "https://github.com/8thwall/8thwall/issues"
   },
   "keywords": [
     "8thwall",
@@ -13,14 +20,22 @@
     "targets",
     "tracking"
   ],
+  "files": [
+    "src/**/*"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/8thwall/8thwall.git",
+    "directory": "apps/image-target-cli"
+  },
   "author": "8th Wall Team",
   "license": "MIT",
   "dependencies": {
-    "@types/node": "^25.2.3",
-    "@types/sharp": "^0.31.1",
     "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "@types/node": "^25.2.3",
+    "@types/sharp": "^0.31.1",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Context

With the repo growing, asking users to clone the repo to use the cli is a bit of pain. 



Published some alpha releases using `npm publish --access=public` - Note that publishing a version marked as `-alpha.0` in the package.json will still bump the latest tag unless you specify a different tag, so won't do that again. https://docs.npmjs.com/adding-dist-tags-to-packages#publishing-a-package-with-a-dist-tag

Now, it can be invoked through `npx`. 

## Testing

(Asked Paris to test just in case it wouldn't be the same on my machine)

```
~/repo/8thwall npx @8thwall/image-target-cli@latest
Enter the path to the image file:
/Users/paris/Documents/PuttPuttParadise.png
Select the image type:
1) flat (default)
2) cylinder
3) cone

1
Use default crop? [Y/n]:

Enter the output folder:
> ~/tmp
Enter a name for the image target:
foo
Image target data saved to: /Users/paris/tmp/foo.json
```