### PR TITLE
Switch to @repo specifier for root imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -211,7 +211,7 @@ module.exports = {
       'typescript': {},  // this loads <rootdir>/tsconfig.json to eslint
       'alias': {
         'map': [
-          ['@nia', `${__dirname}/`],
+          ['@repo', `${__dirname}/`],
         ],
         'extensions': ['.js', '.jsx', '.ts', '.tsx'],
       },

--- a/bzl/examples/hello-ts-test.ts
+++ b/bzl/examples/hello-ts-test.ts
@@ -1,4 +1,4 @@
-import {chai} from '@nia/bzl/js/chai-js'
+import {chai} from '@repo/bzl/js/chai-js'
 
 const {describe, it} = globalThis as any
 

--- a/bzl/examples/js/import/externalized-npm-test.ts
+++ b/bzl/examples/js/import/externalized-npm-test.ts
@@ -3,7 +3,7 @@
 
 import webpack from 'webpack'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 describe('webpack', () => {
   it('exposes the expected API', async () => {

--- a/bzl/examples/js/import/transitive-definitions-test.ts
+++ b/bzl/examples/js/import/transitive-definitions-test.ts
@@ -2,7 +2,7 @@
 
 import {promises as fs} from 'fs'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 describe('transitive definitions with full_dts', () => {
   it('Contains type declarations from transitive deps', async () => {

--- a/bzl/examples/js/import/type-only-validate-test.ts
+++ b/bzl/examples/js/import/type-only-validate-test.ts
@@ -2,9 +2,9 @@
 
 import {promises as fs} from 'fs'
 
-import {DATA} from '@nia/bzl/examples/js/import/type-only-lib'
+import {DATA} from '@repo/bzl/examples/js/import/type-only-lib'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 describe('type only import', () => {
   it('Does not contain direct import of lib', async () => {

--- a/bzl/examples/js/import/type-only.ts
+++ b/bzl/examples/js/import/type-only.ts
@@ -4,7 +4,7 @@
 // @dep(//bzl/examples/js/import:type-only-lib-declarations)
 
 // @inliner-skip-next
-import type * as Lib from '@nia/bzl/examples/js/import/type-only-lib'
+import type * as Lib from '@repo/bzl/examples/js/import/type-only-lib'
 
 const myFn = (argument: Lib.ExampleType) => {
   // eslint-disable-next-line no-console

--- a/bzl/examples/js/interop/import/js-es6-nia.js
+++ b/bzl/examples/js/interop/import/js-es6-nia.js
@@ -1,9 +1,9 @@
-import data1 from '@nia/bzl/examples/js/interop/export/commonjs-default'
-import {data as data2} from '@nia/bzl/examples/js/interop/export/commonjs-named'
-import data3 from '@nia/bzl/examples/js/interop/export/js-es6-default'
-import {data as data4} from '@nia/bzl/examples/js/interop/export/js-es6-named'
-import data5 from '@nia/bzl/examples/js/interop/export/ts-es6-default'
-import {data as data6} from '@nia/bzl/examples/js/interop/export/ts-es6-named'
-import {data as data7} from '@nia/bzl/examples/js/interop/export/capnp-style'
+import data1 from '@repo/bzl/examples/js/interop/export/commonjs-default'
+import {data as data2} from '@repo/bzl/examples/js/interop/export/commonjs-named'
+import data3 from '@repo/bzl/examples/js/interop/export/js-es6-default'
+import {data as data4} from '@repo/bzl/examples/js/interop/export/js-es6-named'
+import data5 from '@repo/bzl/examples/js/interop/export/ts-es6-default'
+import {data as data6} from '@repo/bzl/examples/js/interop/export/ts-es6-named'
+import {data as data7} from '@repo/bzl/examples/js/interop/export/capnp-style'
 
 console.log('js-es6-nia', [data1, data2, data3, data4, data5, data6, data7].map(e => e.id))

--- a/bzl/examples/js/interop/import/ts-es6-nia.ts
+++ b/bzl/examples/js/interop/import/ts-es6-nia.ts
@@ -1,9 +1,9 @@
-import data1 from '@nia/bzl/examples/js/interop/export/commonjs-default'
-import {data as data2} from '@nia/bzl/examples/js/interop/export/commonjs-named'
-import data3 from '@nia/bzl/examples/js/interop/export/js-es6-default'
-import {data as data4} from '@nia/bzl/examples/js/interop/export/js-es6-named'
-import data5 from '@nia/bzl/examples/js/interop/export/ts-es6-default'
-import {data as data6} from '@nia/bzl/examples/js/interop/export/ts-es6-named'
-import {data as data7} from '@nia/bzl/examples/js/interop/export/capnp-style'
+import data1 from '@repo/bzl/examples/js/interop/export/commonjs-default'
+import {data as data2} from '@repo/bzl/examples/js/interop/export/commonjs-named'
+import data3 from '@repo/bzl/examples/js/interop/export/js-es6-default'
+import {data as data4} from '@repo/bzl/examples/js/interop/export/js-es6-named'
+import data5 from '@repo/bzl/examples/js/interop/export/ts-es6-default'
+import {data as data6} from '@repo/bzl/examples/js/interop/export/ts-es6-named'
+import {data as data7} from '@repo/bzl/examples/js/interop/export/capnp-style'
 
 console.log('ts-es6-nia', [data1, data2, data3, data4, data5, data6, data7].map(e => e.id))

--- a/bzl/examples/js/resolve/unique-test.ts
+++ b/bzl/examples/js/resolve/unique-test.ts
@@ -1,10 +1,10 @@
 import * as Absolute from 'bzl/examples/js/resolve/unique'
 
-import * as Nia from '@nia/bzl/examples/js/resolve/unique'
+import * as Root from '@repo/bzl/examples/js/resolve/unique'
 
 import * as Relative from './unique'
 
-const uniqueObjects = new Set([Absolute, Nia, Relative].map(e => e.get()))
+const uniqueObjects = new Set([Absolute, Root, Relative].map(e => e.get()))
 
 if (uniqueObjects.size !== 1) {
   throw new Error('Expected all objects to be the same.')

--- a/bzl/examples/js/syntax/class-test.ts
+++ b/bzl/examples/js/syntax/class-test.ts
@@ -3,7 +3,7 @@
 
 import {promises as fs} from 'fs'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 describe('class statements in ts', () => {
   it('are left as-is', async () => {

--- a/bzl/js/webpack-build.ts
+++ b/bzl/js/webpack-build.ts
@@ -105,12 +105,12 @@ type BeforeResolveData = {
 // NOTE(christoph): This is supposed to do the same thing as NormalModuleReplacementPlugin
 // but for some reason there were these resource.dependencies that were present that
 // also needed to be rewritten for it to work.
-const createNiaResolverPlugin = (roots: string[]) => {
+const createRootResolverPlugin = (roots: string[]) => {
   const handleBeforeResolve = (resource: BeforeResolveData) => {
-    if (!resource.request?.startsWith('@nia/')) {
+    if (!resource.request?.startsWith('@repo/')) {
       return
     }
-    const importPath = resource.request.substring('@nia/'.length)
+    const importPath = resource.request.substring('@repo/'.length)
     const resolvedPath = mapAndFind(EXTENSIONS, ext => mapAndFind(roots, (root) => {
       const fullPath = path.join(root, importPath + ext)
       try {
@@ -142,9 +142,9 @@ const createNiaResolverPlugin = (roots: string[]) => {
   return {
     apply(compiler: Webpack.Compiler) {
       compiler.hooks.normalModuleFactory.tap(
-        'NiaResolverPlugin',
+        'RootResolverPlugin',
         (factory) => {
-          factory.hooks.beforeResolve.tap('NiaResolverPlugin', handleBeforeResolve)
+          factory.hooks.beforeResolve.tap('RootResolverPlugin', handleBeforeResolve)
         }
       )
     },
@@ -263,7 +263,7 @@ const resolveBuildPaths = async (npmRule, includes) => {
   // the same resolution logic specified in the normal webpack config.
   const typescriptIncludes = {
     'tslib': [resolveLib('tslib')],
-    '@nia/*': topLevelImportPaths,
+    '@repo/*': topLevelImportPaths,
     '*': topLevelImportPaths,
   }
 
@@ -486,7 +486,7 @@ const genConfig = async ({
   const plugins: Webpack.Configuration['plugins'] = [
     // Allow only one chunk, as bazel is expecting a single output.
     new LimitChunkCountPlugin({maxChunks: 1}),
-    createNiaResolverPlugin([cwd, ...includes.map((e: string) => path.join(cwd, e))]),
+    createRootResolverPlugin([cwd, ...includes.map((e: string) => path.join(cwd, e))]),
   ]
 
   if (headerPath || footerPath) {

--- a/bzl/npmpackage/exhaustive-typecheck-test.ts
+++ b/bzl/npmpackage/exhaustive-typecheck-test.ts
@@ -5,7 +5,7 @@
 import {promises as fs} from 'fs'
 import path from 'path'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 const runfiles = process.env.RUNFILES_DIR!
 

--- a/c8/browser/gesture-detector.ts
+++ b/c8/browser/gesture-detector.ts
@@ -1,6 +1,6 @@
-import BROWSERWASM from '@nia/c8/browser/browser-wasm'
+import BROWSERWASM from '@repo/c8/browser/browser-wasm'
 
-import {writeStringToEmscriptenHeap} from '@nia/c8/ems/ems'
+import {writeStringToEmscriptenHeap} from '@repo/c8/ems/ems'
 import {createMouseToTouchTranslator} from './mouse-to-touch-translater'
 
 interface GestureState {

--- a/c8/ecs/src/runtime/BUILD
+++ b/c8/ecs/src/runtime/BUILD
@@ -910,7 +910,7 @@ js_library(
 genrule(
     name = "ecs-asm",
     outs = ["ecs-asm.ts"],
-    cmd = "echo \"import ECS from '@nia/c8/ecs/ecs-asm';export default ECS;\" > $@",
+    cmd = "echo \"import ECS from '@repo/c8/ecs/ecs-asm';export default ECS;\" > $@",
 )
 
 js_library(

--- a/c8/ecs/src/runtime/asm.ts
+++ b/c8/ecs/src/runtime/asm.ts
@@ -3,10 +3,10 @@
 // @attr[](srcs = ":ecs-asm")
 // @dep(//c8/ecs:ecs-asm)
 // @inliner-skip-next
-import ECS from '@nia/c8/ecs/src/runtime/ecs-asm'
+import ECS from '@repo/c8/ecs/src/runtime/ecs-asm'
 /* eslint-enable */
 
-import type {EcsAsm} from '@nia/c8/ecs/gen/asm-types'
+import type {EcsAsm} from '@repo/c8/ecs/gen/asm-types'
 
 let verbose = false
 let loaded = false

--- a/c8/ecs/src/runtime/behavior-test.ts
+++ b/c8/ecs/src/runtime/behavior-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/bitflags-test.ts
+++ b/c8/ecs/src/runtime/bitflags-test.ts
@@ -1,4 +1,4 @@
-import {describe, it, beforeEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, assert} from '@repo/bzl/js/chai-js'
 
 import {setBitFlag, enableBitFlag, disableBitFlag, isBitFlagEnabled} from './bitflags'
 

--- a/c8/ecs/src/runtime/collider-schema-test.ts
+++ b/c8/ecs/src/runtime/collider-schema-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/component-callbacks-test.ts
+++ b/c8/ecs/src/runtime/component-callbacks-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/component-schema-test.ts
+++ b/c8/ecs/src/runtime/component-schema-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/component-test.ts
+++ b/c8/ecs/src/runtime/component-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert as chaiAssert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert as chaiAssert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/component-visibility-test.ts
+++ b/c8/ecs/src/runtime/component-visibility-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/components/transform-components-test.ts
+++ b/c8/ecs/src/runtime/components/transform-components-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from '../test-env'
 import {ecs} from '../test-runtime-lib'

--- a/c8/ecs/src/runtime/cursor-test.ts
+++ b/c8/ecs/src/runtime/cursor-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert as chaiAssert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert as chaiAssert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/delete-entity-test.ts
+++ b/c8/ecs/src/runtime/delete-entity-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert as chaiAssert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert as chaiAssert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/disabled-test.ts
+++ b/c8/ecs/src/runtime/disabled-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/effects-manager-test.ts
+++ b/c8/ecs/src/runtime/effects-manager-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/entity-impl-test.ts
+++ b/c8/ecs/src/runtime/entity-impl-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
-import {describe, it, assert, beforeEach, afterEach} from '@nia/bzl/js/chai-js'
+import {describe, it, assert, beforeEach, afterEach} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/entity-impl-transforms-test.ts
+++ b/c8/ecs/src/runtime/entity-impl-transforms-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(esnext = 1)
 // @attr(externalize_npm = 1)
-import {describe, it, beforeEach, afterEach} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import type {World} from './world'

--- a/c8/ecs/src/runtime/events-test.ts
+++ b/c8/ecs/src/runtime/events-test.ts
@@ -1,4 +1,4 @@
-import {describe, it, before, assert, beforeEach} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert, beforeEach} from '@repo/bzl/js/chai-js'
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)

--- a/c8/ecs/src/runtime/external-three-test.ts
+++ b/c8/ecs/src/runtime/external-three-test.ts
@@ -1,7 +1,7 @@
 // @attr[](data = "//c8/ecs/src/runtime")
 // @attr[](data = "//c8/ecs/src/runtime:plugin")
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 import path from 'path'
 import {promises as fs} from 'fs'
 

--- a/c8/ecs/src/runtime/flecs-prefab-test.ts
+++ b/c8/ecs/src/runtime/flecs-prefab-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, assert, beforeEach, afterEach, before} from '@nia/bzl/js/chai-js'
+import {describe, it, assert, beforeEach, afterEach, before} from '@repo/bzl/js/chai-js'
 
 import './test-env'
 import {asm, asmReady} from './asm'

--- a/c8/ecs/src/runtime/geometry-test.ts
+++ b/c8/ecs/src/runtime/geometry-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, assert, beforeEach, afterEach} from '@nia/bzl/js/chai-js'
+import {describe, it, assert, beforeEach, afterEach} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/get-children-test.ts
+++ b/c8/ecs/src/runtime/get-children-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, assert, beforeEach, before} from '@nia/bzl/js/chai-js'
+import {describe, it, assert, beforeEach, before} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/independent-observer-test.ts
+++ b/c8/ecs/src/runtime/independent-observer-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/lifecycle-test.ts
+++ b/c8/ecs/src/runtime/lifecycle-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert as chaiAssert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert as chaiAssert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/memory-test.ts
+++ b/c8/ecs/src/runtime/memory-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import {
   getDefaults, getSchemaAlignment, getSchemaSize, toOrderedSchema,

--- a/c8/ecs/src/runtime/persistent-test.ts
+++ b/c8/ecs/src/runtime/persistent-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/physics-test.ts
+++ b/c8/ecs/src/runtime/physics-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/registry-test.ts
+++ b/c8/ecs/src/runtime/registry-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/scene-prefab-test.ts
+++ b/c8/ecs/src/runtime/scene-prefab-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/scene-sky-test.ts
+++ b/c8/ecs/src/runtime/scene-sky-test.ts
@@ -3,7 +3,7 @@
 // @attr(externalize_npm = 0)
 // @attr(esnext = 1)
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import {convertSceneSkyToEffectsManagerSky} from './scene-sky'
 

--- a/c8/ecs/src/runtime/state-machine-test.ts
+++ b/c8/ecs/src/runtime/state-machine-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/string-storage-test.ts
+++ b/c8/ecs/src/runtime/string-storage-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {globalStringMap} from './string-storage'
 

--- a/c8/ecs/src/runtime/system-observers-test.ts
+++ b/c8/ecs/src/runtime/system-observers-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert as chaiAssert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert as chaiAssert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/systems-observers-multi-terms-test.ts
+++ b/c8/ecs/src/runtime/systems-observers-multi-terms-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, assert as chaiAssert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, assert as chaiAssert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/test-runtime-lib-inner.d.ts
+++ b/c8/ecs/src/runtime/test-runtime-lib-inner.d.ts
@@ -1,2 +1,2 @@
 // @inliner-off
-export * from '@nia/c8/ecs/src/runtime/test-runtime-bin'
+export * from '@repo/c8/ecs/src/runtime/test-runtime-bin'

--- a/c8/ecs/src/runtime/transform-manager-get-test.ts
+++ b/c8/ecs/src/runtime/transform-manager-get-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(esnext = 1)
 // @attr(externalize_npm = 1)
-import {describe, it, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/transform-manager-look-at-test.ts
+++ b/c8/ecs/src/runtime/transform-manager-look-at-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(esnext = 1)
 // @attr(externalize_npm = 1)
-import {describe, it, beforeEach, afterEach} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/transform-manager-rotate-test.ts
+++ b/c8/ecs/src/runtime/transform-manager-rotate-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(esnext = 1)
 // @attr(externalize_npm = 1)
-import {describe, it, beforeEach, afterEach} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/transform-manager-set-test.ts
+++ b/c8/ecs/src/runtime/transform-manager-set-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(esnext = 1)
 // @attr(externalize_npm = 1)
-import {describe, it, beforeEach, afterEach} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/transform-manager-temp-variable-test.ts
+++ b/c8/ecs/src/runtime/transform-manager-temp-variable-test.ts
@@ -2,7 +2,7 @@
 // @attr[](data = "transform-manager.ts")
 // @attr(esnext = 1)
 // @attr(externalize_npm = 1)
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import {parse} from '@babel/parser'
 import type {ArrowFunctionExpression, VariableDeclaration} from '@babel/types'

--- a/c8/ecs/src/runtime/transform-manager-translate-test.ts
+++ b/c8/ecs/src/runtime/transform-manager-translate-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(esnext = 1)
 // @attr(externalize_npm = 1)
-import {describe, it, beforeEach, afterEach} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/transform-test-helpers.ts
+++ b/c8/ecs/src/runtime/transform-test-helpers.ts
@@ -1,6 +1,6 @@
 // @attr(testonly = 1)
 
-import {assert} from '@nia/bzl/js/chai-js'
+import {assert} from '@repo/bzl/js/chai-js'
 
 import {ecs} from './test-runtime-lib'
 import type {QuatSource} from './math/quat'

--- a/c8/ecs/src/runtime/world-prefab-test.ts
+++ b/c8/ecs/src/runtime/world-prefab-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/runtime/world-test.ts
+++ b/c8/ecs/src/runtime/world-test.ts
@@ -2,7 +2,7 @@
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
 
-import {describe, it, before, beforeEach, afterEach, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, before, beforeEach, afterEach, assert} from '@repo/bzl/js/chai-js'
 
 import {initThree} from './test-env'
 import {ecs} from './test-runtime-lib'

--- a/c8/ecs/src/shared/crdt-prefab-test.ts
+++ b/c8/ecs/src/shared/crdt-prefab-test.ts
@@ -1,6 +1,6 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 import type {DeepReadonly} from 'ts-essentials'
 
 import {

--- a/c8/ecs/src/shared/crdt-test.ts
+++ b/c8/ecs/src/shared/crdt-test.ts
@@ -1,9 +1,9 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 import type {DeepReadonly} from 'ts-essentials'
 
-import * as Automerge from '@nia/c8/ecs/src/shared/automerge'
+import * as Automerge from '@repo/c8/ecs/src/shared/automerge'
 
 import {
   createEmptySceneDoc, loadSceneDoc, fixStringDuplication, Json, SceneDoc,

--- a/c8/ecs/src/shared/crdt-undo-test.ts
+++ b/c8/ecs/src/shared/crdt-undo-test.ts
@@ -1,6 +1,6 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 import type {DeepReadonly} from 'ts-essentials'
 
 import {createEmptySceneDoc, loadSceneDoc} from './crdt'

--- a/c8/ecs/src/shared/crdt.ts
+++ b/c8/ecs/src/shared/crdt.ts
@@ -1,6 +1,6 @@
 import type {DeepReadonly} from 'ts-essentials'
 
-import * as Automerge from '@nia/c8/ecs/src/shared/automerge'
+import * as Automerge from '@repo/c8/ecs/src/shared/automerge'
 
 import type {
   GraphObject, PrefabInstanceChildren, PrefabInstanceDeletions, SceneGraph, Space, Spaces,

--- a/c8/ecs/src/shared/determine-ui-order-test.ts
+++ b/c8/ecs/src/shared/determine-ui-order-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import type {LayoutNode} from './flex-styles'
 import {determineUiOrder} from './determine-ui-order'

--- a/c8/ecs/src/shared/object-hierarchy-test.ts
+++ b/c8/ecs/src/shared/object-hierarchy-test.ts
@@ -1,7 +1,7 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
 // @attr(esnext = 1)
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import type {BaseGraphObject, GraphObject, PrefabInstanceChildren, SceneGraph} from './scene-graph'
 import {getParentInstanceId, isDescendantOf} from './object-hierarchy'

--- a/c8/ecs/src/shared/parse-component-ast-test.ts
+++ b/c8/ecs/src/shared/parse-component-ast-test.ts
@@ -1,6 +1,6 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
-import {describe, it, assert, chai, chaiExclude} from '@nia/bzl/js/chai-js'
+import {describe, it, assert, chai, chaiExclude} from '@repo/bzl/js/chai-js'
 
 import {parseComponentAst} from './parse-component-ast'
 import type {Schema} from './schema'

--- a/c8/ecs/src/shared/schema-utility-test.ts
+++ b/c8/ecs/src/shared/schema-utility-test.ts
@@ -1,6 +1,6 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import {NUMERIC_SCHEMA_TYPES} from './component-constants'
 import {

--- a/c8/ecs/src/shared/three-layers-test.ts
+++ b/c8/ecs/src/shared/three-layers-test.ts
@@ -1,6 +1,6 @@
 // @package(npm-ecs)
 // @attr(externalize_npm = 1)
-import {assert, it, describe} from '@nia/bzl/js/chai-js'
+import {assert, it, describe} from '@repo/bzl/js/chai-js'
 
 import {THREE_LAYERS} from './three-layers'
 

--- a/c8/ecs/src/shared/tooltip-completion-test.ts
+++ b/c8/ecs/src/shared/tooltip-completion-test.ts
@@ -7,7 +7,7 @@
 import path from 'path'
 import fs from 'fs'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import '../runtime/test-env'
 import {ecs} from '../runtime/test-runtime-lib'

--- a/c8/ecs/src/shared/tooltip-defaults-test.ts
+++ b/c8/ecs/src/shared/tooltip-defaults-test.ts
@@ -6,7 +6,7 @@
 import path from 'path'
 import fs from 'fs'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import '../runtime/test-env'
 import {ecs} from '../runtime/test-runtime-lib'

--- a/c8/ecs/src/shared/tooltip-types-test.ts
+++ b/c8/ecs/src/shared/tooltip-types-test.ts
@@ -6,7 +6,7 @@
 import path from 'path'
 import fs from 'fs'
 
-import {describe, it, assert} from '@nia/bzl/js/chai-js'
+import {describe, it, assert} from '@repo/bzl/js/chai-js'
 
 import '../runtime/test-env'
 import {ecs} from '../runtime/test-runtime-lib'

--- a/c8/ecs/tools/features-test.ts
+++ b/c8/ecs/tools/features-test.ts
@@ -1,9 +1,9 @@
-import {assert} from '@nia/bzl/js/chai-js'
+import {assert} from '@repo/bzl/js/chai-js'
 
 // @dep(//c8/ecs/tools:generated-features-list)
-import * as FEATURES from '@nia/c8/ecs/tools/generated-features-list'
+import * as FEATURES from '@repo/c8/ecs/tools/generated-features-list'
 
-import {EDITIONS} from '@nia/c8/ecs/src/shared/features/edition'
+import {EDITIONS} from '@repo/c8/ecs/src/shared/features/edition'
 
 const EXPECTED_EDITIONS: string[][] = []
 

--- a/c8/ecs/tools/generate-asm-types.ts
+++ b/c8/ecs/tools/generate-asm-types.ts
@@ -10,7 +10,7 @@ import {
   cppTypeToTs,
   findDeclarations,
   parameterToTs,
-} from '@nia/bzl/js/codegen/generate-ts-from-cpp'
+} from '@repo/bzl/js/codegen/generate-ts-from-cpp'
 
 const run = async (ccPaths: string[]) => {
   const declarations: Declaration[] = []

--- a/c8/ecs/tools/generate-features-list.ts
+++ b/c8/ecs/tools/generate-features-list.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 /* NOTE(christoph): This script generates typescript code that looks like:
 
 ```
-export * from '@nia/c8/ecs/src/shared/features/jolt'
+export * from '@repo/c8/ecs/src/shared/features/jolt'
 ```
 
 With a line for each file in the features directory (except edition.ts) */
@@ -13,7 +13,7 @@ With a line for each file in the features directory (except edition.ts) */
 const exportLines: string[] = []
 const RUNFILES_DIR = process.env.RUNFILES_DIR!
 fs.readdirSync(`${RUNFILES_DIR}/_main/c8/ecs/src/shared/features`).forEach((entry) => {
-  exportLines.push(`export * from '@nia/c8/ecs/src/shared/features/${entry.replace(/\.ts$/g, '')}'`)
+  exportLines.push(`export * from '@repo/c8/ecs/src/shared/features/${entry.replace(/\.ts$/g, '')}'`)
 })
 
 // eslint-disable-next-line no-console

--- a/c8/ecs/tools/generate-metadata.ts
+++ b/c8/ecs/tools/generate-metadata.ts
@@ -10,12 +10,12 @@
 import {promises as fs} from 'fs'
 import path from 'path'
 
-import * as FEATURES from '@nia/c8/ecs/tools/generated-features-list'
+import * as FEATURES from '@repo/c8/ecs/tools/generated-features-list'
 
-import {EDITIONS} from '@nia/c8/ecs/src/shared/features/edition'
+import {EDITIONS} from '@repo/c8/ecs/src/shared/features/edition'
 
-import type {RuntimeMetadata} from '@nia/c8/ecs/src/shared/runtime-version'
-import {parseComponentAst} from '@nia/c8/ecs/src/shared/parse-component-ast'
+import type {RuntimeMetadata} from '@repo/c8/ecs/src/shared/runtime-version'
+import {parseComponentAst} from '@repo/c8/ecs/src/shared/parse-component-ast'
 
 const FILES_TO_INCLUDE = [
   'src/runtime/animation.ts',

--- a/c8/ecs/tsconfig.json
+++ b/c8/ecs/tsconfig.json
@@ -19,8 +19,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "paths": {
-      "@nia/c8/ecs/*": ["./*"],
-      "@nia/bzl/js/*": ["../../bzl/js/*"]
+      "@repo/c8/ecs/*": ["./*"],
+      "@repo/bzl/js/*": ["../../bzl/js/*"]
     }
   },
   "include": [

--- a/c8/ecs/webpack.runtime.js
+++ b/c8/ecs/webpack.runtime.js
@@ -68,7 +68,7 @@ module.exports = (ctx) => {
     resolve: {
       extensions: ['.ts', '.js', '.json'],
       alias: {
-        '@nia/c8/ecs': __dirname,
+        '@repo/c8/ecs': __dirname,
       },
     },
     module: {rules},

--- a/c8/model/web/web-model-view.ts
+++ b/c8/model/web/web-model-view.ts
@@ -1,12 +1,12 @@
-import WEBMODELVIEW from '@nia/c8/model/web/web-model-view-wasm'
+import WEBMODELVIEW from '@repo/c8/model/web/web-model-view-wasm'
 
-import {writeStringToEmscriptenHeap, writeArrayToEmscriptenHeap} from '@nia/c8/ems/ems'
-// TODO: Import from @nia/c8/xrapi/xrapi-types
+import {writeStringToEmscriptenHeap, writeArrayToEmscriptenHeap} from '@repo/c8/ems/ems'
+// TODO: Import from @repo/c8/xrapi/xrapi-types
 // import type {
 //   DomHighResTimeStamp, XrFrame, XrFrameCallback, XrReferenceSpace, XrSession,
-// } from '@nia/c8/xrapi/xrapi-types'
+// } from '@repo/c8/xrapi/xrapi-types'
 
-import {createMouseToTouchTranslator} from '@nia/c8/browser/mouse-to-touch-translater'
+import {createMouseToTouchTranslator} from '@repo/c8/browser/mouse-to-touch-translater'
 
 import {ModelManager} from './model-manager'
 import type {ModelSrc} from './model-manager-types'

--- a/reality/app/xr/js/src/globals.d.ts
+++ b/reality/app/xr/js/src/globals.d.ts
@@ -14,4 +14,4 @@ declare var AFRAME: any
 declare var omni8: any
 
 // @dep(//reality/app/xr/js:buildif)
-declare var BuildIf: import('@nia/reality/app/xr/js/buildif').BuildIfReplacements
+declare var BuildIf: import('@repo/reality/app/xr/js/buildif').BuildIfReplacements

--- a/reality/app/xr/js/src/tracking-controller.ts
+++ b/reality/app/xr/js/src/tracking-controller.ts
@@ -37,10 +37,10 @@ import {
   ImageTargetData,
   ProcessedImageTargetData,
   DetectedImageTarget,
-} from '@nia/reality/shared/engine/image-targets'
+} from '@repo/reality/shared/engine/image-targets'
 
-import type {XrccModule} from '@nia/reality/app/xr/js/src/types/xrcc'
-import type {XrTrackingccModule} from '@nia/reality/app/xr/js/src/types/xrtrackingcc'
+import type {XrccModule} from '@repo/reality/app/xr/js/src/types/xrcc'
+import type {XrTrackingccModule} from '@repo/reality/app/xr/js/src/types/xrtrackingcc'
 
 // For window._c8
 // @dep(//reality/app/xr/js/src/types:xrmodule)

--- a/reality/app/xr/js/src/types/callbacks.ts
+++ b/reality/app/xr/js/src/types/callbacks.ts
@@ -1,4 +1,4 @@
-import type {ImageTargetData} from '@nia/reality/shared/engine/image-targets'
+import type {ImageTargetData} from '@repo/reality/shared/engine/image-targets'
 
 import type * as Pipeline from './pipeline'
 import type {CameraStatusChangeDetails} from './pipeline'

--- a/reality/app/xr/js/src/types/xrcc.ts
+++ b/reality/app/xr/js/src/types/xrcc.ts
@@ -2,7 +2,7 @@
 //   npm run refresh-types
 
 // @inliner-off
-import type {EmscriptenModule} from '@nia/reality/app/xr/js/src/types/emscripten'
+import type {EmscriptenModule} from '@repo/reality/app/xr/js/src/types/emscripten'
 
 /* eslint-disable import/group-exports, camelcase, max-len */
 

--- a/reality/app/xr/js/src/types/xrfacecc.ts
+++ b/reality/app/xr/js/src/types/xrfacecc.ts
@@ -2,7 +2,7 @@
 //   npm run refresh-types
 
 // @inliner-off
-import type {EmscriptenModule} from '@nia/reality/app/xr/js/src/types/emscripten'
+import type {EmscriptenModule} from '@repo/reality/app/xr/js/src/types/emscripten'
 
 /* eslint-disable import/group-exports, camelcase, max-len */
 

--- a/reality/app/xr/js/src/types/xrmodule.d.ts
+++ b/reality/app/xr/js/src/types/xrmodule.d.ts
@@ -2,7 +2,7 @@
 //   npm run refresh-types
 
 // @inliner-off
-import type {EmscriptenTexture} from '@nia/reality/app/xr/js/src/types/emscripten'
+import type {EmscriptenTexture} from '@repo/reality/app/xr/js/src/types/emscripten'
 
 /* eslint-disable import/group-exports, camelcase, max-len */
 

--- a/reality/app/xr/js/src/types/xrtrackingcc.ts
+++ b/reality/app/xr/js/src/types/xrtrackingcc.ts
@@ -2,7 +2,7 @@
 //   npm run refresh-types
 
 // @inliner-off
-import type {EmscriptenModule} from '@nia/reality/app/xr/js/src/types/emscripten'
+import type {EmscriptenModule} from '@repo/reality/app/xr/js/src/types/emscripten'
 
 /* eslint-disable import/group-exports, camelcase, max-len */
 

--- a/reality/app/xr/js/tools/generate-xrcc-types.ts
+++ b/reality/app/xr/js/tools/generate-xrcc-types.ts
@@ -11,7 +11,7 @@ import {
   findDeclarations,
   findWindowObjects,
   parameterToTs,
-} from '@nia/bzl/js/codegen/generate-ts-from-cpp'
+} from '@repo/bzl/js/codegen/generate-ts-from-cpp'
 
 const run = async (ccPaths: string[]) => {
   const declarations: Declaration[] = []
@@ -30,7 +30,7 @@ const run = async (ccPaths: string[]) => {
 //   npm run refresh-types
 
 // @inliner-off
-import type {EmscriptenModule} from '@nia/reality/app/xr/js/src/types/emscripten'
+import type {EmscriptenModule} from '@repo/reality/app/xr/js/src/types/emscripten'
 
 /* eslint-disable import/group-exports, camelcase, max-len */
 `)

--- a/reality/app/xr/js/tools/generate-xrchunk-types.ts
+++ b/reality/app/xr/js/tools/generate-xrchunk-types.ts
@@ -9,7 +9,7 @@ import {
   cppTypeToTs,
   findDeclarations,
   parameterToTs,
-} from '@nia/bzl/js/codegen/generate-ts-from-cpp'
+} from '@repo/bzl/js/codegen/generate-ts-from-cpp'
 
 const run = async (ccPaths: string[]) => {
   const chunkName = process.argv[2]
@@ -29,7 +29,7 @@ const run = async (ccPaths: string[]) => {
   console.log(`\
 
 // @inliner-off
-import type {EmscriptenModule} from '@nia/reality/app/xr/js/src/types/emscripten'
+import type {EmscriptenModule} from '@repo/reality/app/xr/js/src/types/emscripten'
 
 /* eslint-disable import/group-exports, camelcase, max-len */
 `)

--- a/reality/app/xr/js/tools/generate-xrmodule-types.ts
+++ b/reality/app/xr/js/tools/generate-xrmodule-types.ts
@@ -8,7 +8,7 @@ import {
   Declaration,
   findDeclarations,
   findWindowObjects,
-} from '@nia/bzl/js/codegen/generate-ts-from-cpp'
+} from '@repo/bzl/js/codegen/generate-ts-from-cpp'
 
 const run = async (ccPaths: string[]) => {
   const declarations: Declaration[] = []
@@ -27,7 +27,7 @@ const run = async (ccPaths: string[]) => {
 //   npm run refresh-types
 
 // @inliner-off
-import type {EmscriptenTexture} from '@nia/reality/app/xr/js/src/types/emscripten'
+import type {EmscriptenTexture} from '@repo/reality/app/xr/js/src/types/emscripten'
 
 /* eslint-disable import/group-exports, camelcase, max-len */
 `)

--- a/reality/app/xr/js/tsconfig.json
+++ b/reality/app/xr/js/tsconfig.json
@@ -19,7 +19,7 @@
     "resolveJsonModule": true,
     "target": "es2019",
     "paths": {
-      "@nia/*": ["../../../../*"],
+      "@repo/*": ["../../../../*"],
       "reality/engine/api/*": ["../../../../bazel-out/wasm32-fastbuild/bin/reality/engine/api/*"],
       "reality/engine/api/device/*": ["../../../../bazel-out/wasm32-fastbuild/bin/reality/engine/api/device/*"],
       "reality/engine/api/base/*": ["../../../../bazel-out/wasm32-fastbuild/bin/reality/engine/api/base/*"],

--- a/rules/reality-shared-imports.js
+++ b/rules/reality-shared-imports.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-const DISALLOWED_PREFIX = '@nia/reality/shared/'
+const DISALLOWED_PREFIX = '@repo/reality/shared/'
 
 // NOTE(christoph): This list reflects what is present in the reality/shared directory
 // eslint-disable-next-line max-len
@@ -57,7 +57,7 @@ module.exports = {
     fixable: 'code',
     messages: {
       invalidMessage:
-        'Imports of @nia/reality/shared are only valid if the file exists in reality/shared',
+        'Imports of @repo/reality/shared are only valid if the file exists in reality/shared',
     },
   },
   create(context) {


### PR DESCRIPTION
## Context

Hopefully makes a little more sense than what it was before

## Testing

- Can build xr
- `npm run test` in c8/ecs passes
- `bazel test //bzl/examples/js/...` passes