### PR TITLE
[engine] Add instructions on how to use the distributed engine SLAM using the open source engine pipeline framework

### DIFF
--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -23,3 +23,49 @@ Or, if building for a non-SIMD environment, run:
 ```bash
 bazel build --config=wasmrelease //reality/app/xr/js:bundle
 ```
+
+## Using the open source engine alongside the distributed engine binary
+This open source version of the engine doesn't include SLAM. But the [distributed engine binary](https://github.com/8thwall/engine) does. To use the open source engine for the camera pipeline and the distributed engine binary for SLAM, you can do the following:
+
+1. In `8thwall/reality/app/xr/js/src/chunk-loader.ts`, update from:
+```cpp
+const slamChunk = await import(/* webpackIgnore: true */ chunkBaseUrl + 'xr-tracking.js')
+```
+to:
+```cpp
+// @ts-ignore
+// eslint-disable-next-line
+const slamChunk = await import(/* webpackIgnore: true */ slamUrl)
+```
+This will update the engine to load the SLAM chunk not from the open source engine, but from the distributed engine binary which we will serve alongside your app.
+
+2. Host the open source engine. Right now, we have only tested with a locally served open source engine. But you can host it anywhere you want. To serve the open source engine, run:
+```bash
+~/repo/8thwall bazel run --config=wasmreleasesimd //reality/app/xr/js:serve-xr
+```
+
+3. In your app, serve the distributed engine binary alongside the app. If you downloaded your app from 8thWall.com, it will already do this. An example file structure for your app is:
+```
+my-app/
+  ├── external/
+  │   └── xr/
+  │       ├── xr.js       # Distributed engine binary entry point - with this approach, we don't use xr.js.
+  │       └── xr-slam.js  # The SLAM chunk - this is what we instruct the open source engine to load.
+  ├── src/
+  │   ├── app.js
+  │   ├── index.html
+  │   └── ...
+  ├── config/
+  │   └── webpack.config.js
+  └── package.json
+```
+
+4. In your app, update to load the open source engine. Update `my-app/src/index.html` from:
+```html
+<script crossorigin="anonymous" src="./external/xr/xr.js" data-preload-chunks="slam">
+```
+to:
+```html
+<script crossorigin="anonymous" src="https://192.168.68.55:8888/reality/app/xr/js/xr.js" data-preload-chunks="slam" data-chunk-base-url="/external/xr/"></script>
+```
+Note that if you host the open source engine elsewhere, you should update from `https://192.168.68.55:8888` to your host.

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -25,6 +25,10 @@ bazel build --config=wasmrelease //reality/app/xr/js:bundle
 ```
 
 ## Using the open source engine alongside the distributed engine binary
+
+> [!WARNING]
+> This approach is a work in progress, the real end state will be a version which doesn't require you to serve the open source engine alongside your app.
+
 This open source version of the engine doesn't include SLAM. But the [distributed engine binary](https://github.com/8thwall/engine) does. To use the open source engine for the camera pipeline and the distributed engine binary for SLAM, you can do the following:
 
 1. In `8thwall/reality/app/xr/js/src/chunk-loader.ts`, update from:


### PR DESCRIPTION
### What
If `getusermedia()` or other web APIs change, the [distributed engine binary](https://github.com/8thwall/engine) may break. To work around this, we can use the open source engine (in this repo) for the camera pipeline, and the distributed engine binary for SLAM (`XRController`). Here we add instructions on how to do this.

### Testing
I tested with https://github.com/8thwall/placeground-threejs on both desktop and my iPhone (using ngrok), and was able to use SLAM. I also tested without this change and verified that on my iPhone we don't track, e.g. SLAM doesn't work.

<img width="2032" height="1098" alt="Screenshot 2026-03-16 at 11 44 53 AM" src="https://github.com/user-attachments/assets/621e5683-afb4-432e-974d-b36ee753f9a8" />

<img width="2032" height="1098" alt="Screenshot 2026-03-16 at 11 45 02 AM" src="https://github.com/user-attachments/assets/83554b82-e222-43ad-856f-d9f6d5af40f1" />

<img width="2032" height="1098" alt="Screenshot 2026-03-16 at 11 45 09 AM" src="https://github.com/user-attachments/assets/06ae639b-4c5e-4e2e-a412-bb26129e8f57" />