### PR TITLE
[ecs] Include metadata.json in package

### DIFF
--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8thwall/ecs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The game engine behind 8th Wall Studio",
   "author": "8th Wall Team",
   "license": "MIT",

--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -28,6 +28,7 @@
     "README.md",
     "index.js",
     "index.d.ts",
+    "metadata.json",
     "dist"
   ]
 }


### PR DESCRIPTION
## Context

This should have been included - we want this file to be available so that the desktop app can inspect `node_modules/@8thwall/ecs/metadata.json` to read the metadata for feature detection and component schema.

## Testing

`cd ~/repo/8thwall/packages/ecs && ./tools/prepare.sh && cd tmp && npm pack`

### Before

```
...
npm notice 4.4MB dist/runtime.js
npm notice 111.9kB index.d.ts
npm notice 123B index.js
npm notice 642B package.json
```

### After

```
...
npm notice 4.4MB dist/runtime.js
npm notice 111.9kB index.d.ts
npm notice 123B index.js
npm notice 17.1kB metadata.json
npm notice 663B package.json
```