### PR TITLE
[xrhome] Improve abandonable effect typing

### DIFF
--- a/reality/cloud/xrhome/src/client/hooks/abandonable-effect.ts
+++ b/reality/cloud/xrhome/src/client/hooks/abandonable-effect.ts
@@ -1,11 +1,11 @@
 import {useEffect} from 'react'
 
 // An Abandonable function returns a promise or is a promise itself.
-type Abandonable = (() => Promise<any>) | Promise<any>
+type Abandonable<T> = (() => Promise<T>) | Promise<T>
 
 // The executor of abandonable functions may or may not resolve.
 // If it does resolve, it returns whatever the given returned.
-type AbandonableExecutor = (abandonable: Abandonable) => Promise<any | never>
+type AbandonableExecutor = <T>(abandonable: Abandonable<T>) => Promise<T | never>
 
 // This is the function you make and pass into useAbandonable()
 type AbandonableEffect = (executor: AbandonableExecutor) => (void | Promise<void>)
@@ -45,7 +45,7 @@ const useAbandonableEffect = (effectBodyFn: AbandonableEffect, deps?: any[]) => 
     let canceled = false
 
     // !! Don't forget to await the executor's promise in your code otherwise things won't work !!
-    const executor = (possiblyAbandon: Abandonable) => new Promise((resolve, reject) => {
+    const executor: AbandonableExecutor = possiblyAbandon => new Promise((resolve, reject) => {
       // Early exit, don't even execute the given function.
       if (canceled) {
         return

--- a/reality/cloud/xrhome/src/client/studio/gltf-preview.tsx
+++ b/reality/cloud/xrhome/src/client/studio/gltf-preview.tsx
@@ -73,7 +73,7 @@ const GltfPreviewInner: React.FC<IGltfPreview> = ({
     const isSpecial = ext === 'hdr' || ext === 'exr'
     const loader = isSpecial ? new RGBELoader() : new TextureLoader()
     if (finalEnvMap && finalEnvMap !== 'none') {
-      const texture = await abandon(new Promise((resolve, reject) => {
+      const texture = await abandon(new Promise<Texture>((resolve, reject) => {
         loader.load(finalEnvMap, (text) => {
           text.mapping = EquirectangularReflectionMapping
           resolve(text)

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -118,7 +118,7 @@ const AssetBundleRecommendation = () => {
 
 const WebpackInjectFixRecommendation = () => {
   const {t} = useTranslation(['cloud-studio-pages', 'common'])
-  const [visible, setVisible] = React.useState()
+  const [visible, setVisible] = React.useState(false)
   const {appKey} = useCurrentApp()
   const localSyncContext = useLocalSyncContext()
   useAbandonableEffect(async (abandon) => {
@@ -138,12 +138,12 @@ const WebpackInjectFixRecommendation = () => {
           <BoldButton onClick={async () => {
             await applyProjectConfigFix(appKey, 'inject')
             await localSyncContext.restartServer()
-            setVisible(null)
+            setVisible(false)
           }}
           >
             {t('recommendation_box.fix')}
           </BoldButton>
-          <BoldButton onClick={() => setVisible(null)}>
+          <BoldButton onClick={() => setVisible(false)}>
             {t('recommendation_box.dismiss')}
           </BoldButton>
         </SpaceBetween>


### PR DESCRIPTION
## Context

The the return type was resolving to `any` which hides type errors

## Testing

- `npm run ts:check` passes