### PR TITLE
[xrhome] Loosen typing for class names combine function

### DIFF
--- a/reality/cloud/xrhome/src/client/common/styles.ts
+++ b/reality/cloud/xrhome/src/client/common/styles.ts
@@ -1,4 +1,6 @@
-const combine = (class1: string, class2: string, ...rest: string[]) => (
+type MaybeClass = string | false | undefined | null
+
+const combine = (class1: MaybeClass, class2: MaybeClass, ...rest: MaybeClass[]) => (
   [class1, class2, ...rest].filter(v => v).join(' ')
 )
 


### PR DESCRIPTION
## Context

This clarifies the intention and fixed some errors as I was refactoring for image targets

## Testing

- `npm run ts:check` passes