### PR TITLE
[desktop] Add endpoints for accessing local image targets

### DIFF
--- a/apps/desktop/BUILD
+++ b/apps/desktop/BUILD
@@ -107,3 +107,23 @@ js_binary(
         "//apps/desktop/app:desktop-protocol",
     ],
 )
+
+js_library(
+    name = "requests",
+    srcs = [
+        "requests.ts",
+    ],
+    deps = [
+        "//apps/desktop:errors",
+    ],
+)
+
+js_library(
+    name = "stream-file-response",
+    srcs = [
+        "stream-file-response.ts",
+    ],
+    deps = [
+        "//apps/desktop:errors",
+    ],
+)

--- a/apps/desktop/app/BUILD
+++ b/apps/desktop/app/BUILD
@@ -25,6 +25,7 @@ js_binary(
         "//apps/desktop/app/dev8-socket:dev8-socket-server",
         "//apps/desktop/app/file-sync:protocol",
         "//apps/desktop/app/file-watch:ports",
+        "//apps/desktop/app/image-targets:protocol",
         "//apps/desktop/app/preferences:protocol",
     ],
 )

--- a/apps/desktop/app/file-sync/BUILD
+++ b/apps/desktop/app/file-sync/BUILD
@@ -17,6 +17,7 @@ js_library(
         "//apps/desktop:local-project-db",
         "//apps/desktop:project-helpers",
         "//apps/desktop:query-params",
+        "//apps/desktop:stream-file-response",
         "//apps/desktop/app/file-sync:file-handler-types",
         "//apps/desktop/app/file-sync:paths",
         "//apps/desktop/app/preferences:code-editor",

--- a/apps/desktop/app/file-sync/file-handler.ts
+++ b/apps/desktop/app/file-sync/file-handler.ts
@@ -1,5 +1,5 @@
 import {shell} from 'electron'
-import {createReadStream, createWriteStream, ReadStream, Stats} from 'fs'
+import {createWriteStream, Stats} from 'fs'
 import {mkdir, rm, rename, readdir, stat} from 'fs/promises'
 import path from 'path'
 import {Readable} from 'stream'
@@ -26,24 +26,7 @@ import {
 import {makeJsonResponse} from '../../json-response'
 import {getQueryParams} from '../../query-params'
 import {openInCodeEditor} from '../preferences/code-editor'
-
-const createReadStreamPromise = (filePath: string) => new Promise<ReadStream>((resolve, reject) => {
-  const contentStream = createReadStream(filePath)
-
-  contentStream.on('open', () => {
-    resolve(contentStream)
-  })
-
-  contentStream.on('error', (error) => {
-    if ('code' in error && error.code === 'ENOENT') {
-      reject(makeCodedError('File not found', 404))
-    } else {
-      // eslint-disable-next-line no-console
-      console.error('Error reading file: ', error)
-      reject(makeCodedError('Error reading file', 500))
-    }
-  })
-})
+import {createReadStreamPromise, makeStreamFileResponse} from '../../stream-file-response'
 
 const getLocalFile = withErrorHandlingResponse(async (req: Request) => {
   const requestUrl = new URL(req.url)
@@ -84,19 +67,7 @@ const getLocalFile = withErrorHandlingResponse(async (req: Request) => {
     }
   }
 
-  const contentStream = await createReadStreamPromise(fullPath)
-
-  // log errors that occur when streaming
-  contentStream.on('error', (error) => {
-    // eslint-disable-next-line no-console
-    console.error(`Error reading file '${contentStream.path}':`, error)
-  })
-
-  return new Response(contentStream, {
-    headers: {
-      'Content-Type': mime.lookup(filePath) || 'application/octet-stream',
-    },
-  })
+  return makeStreamFileResponse(fullPath)
 })
 
 const headLocalFile = withErrorHandlingResponse(async (req: Request) => {

--- a/apps/desktop/app/image-targets/BUILD
+++ b/apps/desktop/app/image-targets/BUILD
@@ -1,0 +1,41 @@
+load("//bzl/js:js.bzl", "js_library")
+
+package(default_visibility = [
+    "//apps/desktop:__subpackages__",
+])
+
+js_library(
+    name = "protocol",
+    srcs = [
+        "protocol.ts",
+    ],
+    deps = [
+        "//apps/desktop/app/image-targets:image-target-handler",
+    ],
+)
+
+js_library(
+    name = "image-target-handler",
+    srcs = [
+        "image-target-handler.ts",
+    ],
+    deps = [
+        "//apps/desktop:errors",
+        "//apps/desktop:json-response",
+        "//apps/desktop:local-project-db",
+        "//apps/desktop:query-params",
+        "//apps/desktop:requests",
+        "//apps/desktop:stream-file-response",
+        "//apps/desktop/app/image-targets:image-target-types",
+        "//reality/shared:run-queue",
+        "//reality/shared/desktop:image-target-api",
+        "//reality/shared/desktop:local-sync-types",
+    ],
+)
+
+js_library(
+    name = "image-target-types",
+    srcs = [
+        "image-target-types.ts",
+    ],
+)

--- a/apps/desktop/app/image-targets/image-target-handler.ts
+++ b/apps/desktop/app/image-targets/image-target-handler.ts
@@ -1,0 +1,133 @@
+import path from 'path'
+import fs from 'fs/promises'
+import * as TargetApi from '@repo/reality/shared/desktop/image-target-api'
+import {makeRunQueue} from '@repo/reality/shared/run-queue'
+import type {Project} from '@repo/reality/shared/desktop/local-sync-types'
+
+import {makeCodedError, withErrorHandlingResponse} from '../../errors'
+import {branches, methods, RequestHandler} from '../../requests'
+import {getLocalProject} from '../../local-project-db'
+import {makeJsonResponse} from '../../json-response'
+import {
+  GetTargetParams, GetTextureParams, ListTargetsParams,
+} from './image-target-types'
+import {makeStreamFileResponse} from '../../stream-file-response'
+import {getQueryParams} from '../../query-params'
+
+const loadProject = async (appKey: string) => {
+  const project = getLocalProject(appKey)
+  if (!project) {
+    throw makeCodedError('Project not found', 404)
+  }
+  return project
+}
+
+const getTargetPath = (project: Project, name: string) => (
+  path.join(project.location, 'image-targets', `${name}.json`)
+)
+
+const readTarget = async (targetPath: string): Promise<TargetApi.ImageTargetData> => {
+  const dataString = await fs.readFile(targetPath, 'utf8')
+  return JSON.parse(dataString)
+}
+
+const handleListTargets: RequestHandler = async (req) => {
+  const url = new URL(req.url)
+  const parsedParams = ListTargetsParams.safeParse(getQueryParams(url))
+  if (!parsedParams.data) {
+    throw makeCodedError('Invalid params', 400)
+  }
+  const project = await loadProject(parsedParams.data.appKey)
+  const folder = path.join(project.location, 'image-targets')
+  try {
+    const contents = await fs.readdir(folder)
+    const runQueue = makeRunQueue(10)
+    const targets: TargetApi.ImageTargetData[] = []
+    const invalidPaths: string[] = []
+
+    await Promise.all(
+      contents.filter(e => e.endsWith('.json')).map(async filename => runQueue.next(async () => {
+        try {
+          targets.push(await readTarget(path.join(folder, filename)))
+        } catch (err) {
+          invalidPaths.push(filename)
+        }
+      }))
+    )
+
+    return makeJsonResponse({targets, invalidPaths})
+  } catch (err: any) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+    return makeJsonResponse({targets: []})
+  }
+}
+
+const handleTargetGet: RequestHandler = async (req) => {
+  const url = new URL(req.url)
+  const parsedParams = GetTargetParams.safeParse(getQueryParams(url))
+  if (!parsedParams.data) {
+    throw makeCodedError('Invalid params', 400)
+  }
+  const project = await loadProject(parsedParams.data.appKey)
+  return makeJsonResponse(await readTarget(getTargetPath(project, parsedParams.data.name)))
+}
+
+const extractImagePath = (target: TargetApi.ImageTargetData, type: TargetApi.TargetTextureType) => {
+  switch (type) {
+    case 'cropped':
+      return target.resources?.croppedImage
+    case 'luminance':
+      return target.resources?.luminanceImage
+    case 'geometry':
+      return target.resources?.geometryImage
+    case 'original':
+      return target.resources?.originalImage
+    case 'thumbnail':
+      return target.resources?.thumbnailImage
+    default:
+      return null
+  }
+}
+
+const resolveImagePath = async (targetPath: string, type: TargetApi.TargetTextureType) => {
+  const target = await readTarget(targetPath)
+  const relativePath = extractImagePath(target, type)
+  if (!relativePath) {
+    return null
+    // TODO(christoph): Add fallback heuristic for legacy image format
+  }
+  return path.join(path.dirname(targetPath), relativePath)
+}
+
+const handleGetTexture: RequestHandler = async (req) => {
+  const url = new URL(req.url)
+  const parsedParams = GetTextureParams.safeParse(getQueryParams(url))
+  if (!parsedParams.data) {
+    throw makeCodedError(`Invalid params: ${parsedParams.error.toString()}`, 400)
+  }
+  const project = await loadProject(parsedParams.data.appKey)
+  const targetPath = getTargetPath(project, parsedParams.data.name)
+  const imagePath = await resolveImagePath(targetPath, parsedParams.data.type)
+  if (!imagePath) {
+    throw makeCodedError('Not found', 404)
+  }
+  return makeStreamFileResponse(imagePath)
+}
+
+const handleImageTargetRequest = withErrorHandlingResponse(branches({
+  [TargetApi.LIST_TARGETS_PATH]: methods({
+    GET: handleListTargets,
+  }),
+  [TargetApi.TARGET_PATH]: methods({
+    GET: handleTargetGet,
+  }),
+  [TargetApi.TEXTURE_PATH]: methods({
+    GET: handleGetTexture,
+  }),
+}))
+
+export {
+  handleImageTargetRequest,
+}

--- a/apps/desktop/app/image-targets/image-target-handler.ts
+++ b/apps/desktop/app/image-targets/image-target-handler.ts
@@ -9,7 +9,7 @@ import {branches, methods, RequestHandler} from '../../requests'
 import {getLocalProject} from '../../local-project-db'
 import {makeJsonResponse} from '../../json-response'
 import {
-  GetTargetParams, GetTextureParams, ListTargetsParams,
+  GetTextureParams, ListTargetsParams,
 } from './image-target-types'
 import {makeStreamFileResponse} from '../../stream-file-response'
 import {getQueryParams} from '../../query-params'
@@ -64,16 +64,6 @@ const handleListTargets: RequestHandler = async (req) => {
   }
 }
 
-const handleTargetGet: RequestHandler = async (req) => {
-  const url = new URL(req.url)
-  const parsedParams = GetTargetParams.safeParse(getQueryParams(url))
-  if (!parsedParams.data) {
-    throw makeCodedError('Invalid params', 400)
-  }
-  const project = await loadProject(parsedParams.data.appKey)
-  return makeJsonResponse(await readTarget(getTargetPath(project, parsedParams.data.name)))
-}
-
 const extractImagePath = (target: TargetApi.ImageTargetData, type: TargetApi.TargetTextureType) => {
   switch (type) {
     case 'cropped':
@@ -117,11 +107,8 @@ const handleGetTexture: RequestHandler = async (req) => {
 }
 
 const handleImageTargetRequest = withErrorHandlingResponse(branches({
-  [TargetApi.LIST_TARGETS_PATH]: methods({
+  [TargetApi.LIST_PATH]: methods({
     GET: handleListTargets,
-  }),
-  [TargetApi.TARGET_PATH]: methods({
-    GET: handleTargetGet,
   }),
   [TargetApi.TEXTURE_PATH]: methods({
     GET: handleGetTexture,

--- a/apps/desktop/app/image-targets/image-target-types.ts
+++ b/apps/desktop/app/image-targets/image-target-types.ts
@@ -1,0 +1,28 @@
+import {z} from 'zod'
+
+const ListTargetsParams = z.object({
+  appKey: z.string().nonempty(),
+})
+
+const GetTargetParams = z.object({
+  appKey: z.string().nonempty(),
+  name: z.string().nonempty(),
+})
+
+const GetTextureParams = z.object({
+  appKey: z.string().nonempty(),
+  name: z.string().nonempty(),
+  type: z.enum([
+    'original',
+    'thumbnail',
+    'cropped',
+    'geometry',
+    'luminance',
+  ]),
+})
+
+export {
+  ListTargetsParams,
+  GetTargetParams,
+  GetTextureParams,
+}

--- a/apps/desktop/app/image-targets/image-target-types.ts
+++ b/apps/desktop/app/image-targets/image-target-types.ts
@@ -4,11 +4,6 @@ const ListTargetsParams = z.object({
   appKey: z.string().nonempty(),
 })
 
-const GetTargetParams = z.object({
-  appKey: z.string().nonempty(),
-  name: z.string().nonempty(),
-})
-
 const GetTextureParams = z.object({
   appKey: z.string().nonempty(),
   name: z.string().nonempty(),
@@ -23,6 +18,5 @@ const GetTextureParams = z.object({
 
 export {
   ListTargetsParams,
-  GetTargetParams,
   GetTextureParams,
 }

--- a/apps/desktop/app/image-targets/protocol.ts
+++ b/apps/desktop/app/image-targets/protocol.ts
@@ -1,0 +1,20 @@
+import {protocol, CustomScheme} from 'electron'
+
+import {handleImageTargetRequest} from './image-target-handler'
+
+const IMAGE_TARGETS_SCHEME: CustomScheme = {
+  scheme: 'image-targets',
+  privileges: {
+    supportFetchAPI: true,
+    stream: true,
+  },
+}
+
+const registerImageTargetsHandler = () => {
+  protocol.handle(IMAGE_TARGETS_SCHEME.scheme, handleImageTargetRequest)
+}
+
+export {
+  IMAGE_TARGETS_SCHEME,
+  registerImageTargetsHandler,
+}

--- a/apps/desktop/app/start.ts
+++ b/apps/desktop/app/start.ts
@@ -24,6 +24,7 @@ import {registerPermissionHandler} from './desktop-app/permissions'
 import {navigateToDeepLink} from './desktop-app/deep-link'
 import {setupMenu} from './menu'
 import {createDev8WebSocketServer} from './dev8-socket/dev8-socket-server'
+import {IMAGE_TARGETS_SCHEME, registerImageTargetsHandler} from './image-targets/protocol'
 
 const CONSOLE_WEBSOCKET_PORT = 62009
 
@@ -144,7 +145,12 @@ app.on('window-all-closed', () => {
   app.quit()
 })
 
-protocol.registerSchemesAsPrivileged([DESKTOP_SCHEME, FILE_SYNC_SCHEME, PREFERENCES_SCHEME])
+protocol.registerSchemesAsPrivileged([
+  DESKTOP_SCHEME,
+  FILE_SYNC_SCHEME,
+  PREFERENCES_SCHEME,
+  IMAGE_TARGETS_SCHEME,
+])
 
 // NOTE(johnny): Remove trailing colon
 const protocolName = STUDIO_HUB_PROTOCOL.slice(0, -1)
@@ -162,6 +168,7 @@ app.whenReady()
     registerDesktopAppHandler(distRoot)
     registerFileSyncHandler()
     registerPreferencesHandler()
+    registerImageTargetsHandler()
     maybeUpdateOnBeforeRequest()
 
     const win = createWindow()

--- a/apps/desktop/requests.ts
+++ b/apps/desktop/requests.ts
@@ -1,0 +1,34 @@
+import {makeCodedError} from './errors'
+
+type RequestHandler = (req: Request) => Response | Promise<Response>
+
+type RequestMethod = 'GET' | 'HEAD' | 'PATCH' | 'POST' | string
+
+const methods = (
+  methodMap: Record<RequestMethod, RequestHandler>
+): RequestHandler => (req: Request) => {
+  const handler = methodMap[req.method]
+  if (!handler) {
+    throw makeCodedError('Invalid request method', 405)
+  }
+  return handler(req)
+}
+
+const branches = (branchMap: Record<string, RequestHandler>): RequestHandler => (req: Request) => {
+  const handler = branchMap[new URL(req.url).pathname]
+  if (!handler) {
+    throw makeCodedError('Unknown request path', 404)
+  }
+
+  return handler(req)
+}
+
+export {
+  methods,
+  branches,
+}
+
+export type {
+  RequestHandler,
+  RequestMethod,
+}

--- a/apps/desktop/stream-file-response.ts
+++ b/apps/desktop/stream-file-response.ts
@@ -10,12 +10,6 @@ const createReadStreamPromise = (filePath: string) => new Promise<ReadStream>((r
     resolve(contentStream)
   })
 
-  // log errors that occur when streaming
-  contentStream.on('error', (error) => {
-    // eslint-disable-next-line no-console
-    console.error(`Error reading file '${contentStream.path}':`, error)
-  })
-
   contentStream.on('error', (error) => {
     if ('code' in error && error.code === 'ENOENT') {
       reject(makeCodedError('File not found', 404))

--- a/apps/desktop/stream-file-response.ts
+++ b/apps/desktop/stream-file-response.ts
@@ -1,0 +1,43 @@
+import {createReadStream, ReadStream} from 'fs'
+import mime from 'mime-types'
+
+import {makeCodedError} from './errors'
+
+const createReadStreamPromise = (filePath: string) => new Promise<ReadStream>((resolve, reject) => {
+  const contentStream = createReadStream(filePath)
+
+  contentStream.on('open', () => {
+    resolve(contentStream)
+  })
+
+  // log errors that occur when streaming
+  contentStream.on('error', (error) => {
+    // eslint-disable-next-line no-console
+    console.error(`Error reading file '${contentStream.path}':`, error)
+  })
+
+  contentStream.on('error', (error) => {
+    if ('code' in error && error.code === 'ENOENT') {
+      reject(makeCodedError('File not found', 404))
+    } else {
+      // eslint-disable-next-line no-console
+      console.error('Error reading file: ', error)
+      reject(makeCodedError('Error reading file', 500))
+    }
+  })
+})
+
+const makeStreamFileResponse = async (filePath: string) => {
+  const contentStream = await createReadStreamPromise(filePath)
+
+  return new Response(contentStream, {
+    headers: {
+      'Content-Type': mime.lookup(filePath) || 'application/octet-stream',
+    },
+  })
+}
+
+export {
+  createReadStreamPromise,
+  makeStreamFileResponse,
+}

--- a/reality/shared/desktop/BUILD
+++ b/reality/shared/desktop/BUILD
@@ -50,3 +50,10 @@ js_library(
         "unix-path.ts",
     ],
 )
+
+js_library(
+    name = "image-target-api",
+    srcs = [
+        "image-target-api.ts",
+    ],
+)

--- a/reality/shared/desktop/image-target-api.ts
+++ b/reality/shared/desktop/image-target-api.ts
@@ -1,0 +1,98 @@
+type ReferencedResources = {
+  originalImage: string
+  croppedImage: string
+  thumbnailImage: string
+  luminanceImage: string
+  geometryImage?: string
+}
+
+type ImageTargetData = {
+  imagePath: string
+  metadata: unknown  // User metadata
+  name: string
+  // NOTE(christoph): The "resources" key was added partway during the export window, so not
+  // all projects will contain them
+  resources?: ReferencedResources
+  created: number
+  updated: number
+} & CropResult
+
+interface CropGeometry {
+  top: number
+  left: number
+  width: number
+  height: number
+  isRotated?: boolean
+  originalWidth: number
+  originalHeight: number
+}
+
+type CylinderCropGeometry = CropGeometry & {
+  targetCircumferenceTop: number
+  cylinderSideLength: number
+  cylinderCircumferenceTop: number
+  cylinderCircumferenceBottom: number
+  arcAngle: number
+  coniness: number
+  inputMode: 'ADVANCED' | 'BASIC'
+  unit: 'mm' | 'in'
+}
+
+type ConicalCropGeometry = CylinderCropGeometry & {
+  topRadius: number
+  bottomRadius: number
+}
+
+type PlanarCropResult = {
+  type: 'PLANAR'
+  properties: CropGeometry
+}
+
+type CylinderCropResult = {
+  type: 'CYLINDER'
+  properties: CylinderCropGeometry
+}
+
+type ConicalCropResult = {
+  type: 'CONICAL'
+  properties: ConicalCropGeometry
+}
+
+type CropResult =
+  | PlanarCropResult
+  | CylinderCropResult
+  | ConicalCropResult
+
+const LIST_PATH = '/list'
+const TEXTURE_PATH = '/texture'
+
+type ListTargetsParams = {
+  appKey: string
+}
+
+type ListTargetsResponse = {
+  targets: ImageTargetData[]
+  invalidPaths: string[]
+}
+
+type TargetTextureType = 'original' | 'cropped' | 'geometry' | 'thumbnail' | 'luminance'
+
+type GetTargetTextureParams = {
+  appKey: string
+  name: string
+  type: TargetTextureType
+  v?: string  // Optional, to bust the cache
+}
+
+export {
+  LIST_PATH,
+  TEXTURE_PATH,
+}
+
+export type {
+  ImageTargetData,
+  ListTargetsParams,
+  ListTargetsResponse,
+  GetTargetTextureParams,
+  TargetTextureType,
+}


### PR DESCRIPTION
## Context

Part of #52 

This is setup for supporting local image target editing using the desktop app.

Starting with the read side, follow up will be to add upload/delete 

## Testing

- No lint errors according to `./scripts/lint.sh`
- Can run the app and see:


<img width="1110" height="418" alt="Screenshot 2026-04-14 at 4 14 14 PM" src="https://github.com/user-attachments/assets/bbcb00de-3260-42bf-84fa-c9ddaeda718c" />

<img width="723" height="164" alt="Screenshot 2026-04-14 at 4 13 53 PM" src="https://github.com/user-attachments/assets/0c48c8de-76b6-47ac-8d6b-aec542b70646" />

<img width="717" height="652" alt="Screenshot 2026-04-14 at 4 13 58 PM" src="https://github.com/user-attachments/assets/8b7fcdd1-9cba-4fa0-9266-91e81646219e" />


