### PR TITLE
[image-target-cli] Update code for integration with desktop

### DIFF
--- a/apps/image-target-cli/package.json
+++ b/apps/image-target-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8thwall/image-target-cli",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Generate 8th Wall Image Target Metadata",
   "main":  "src/index.js",
   "bin": {

--- a/apps/image-target-cli/package.json
+++ b/apps/image-target-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8thwall/image-target-cli",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Generate 8th Wall Image Target Metadata",
   "main":  "src/index.js",
   "bin": {
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "npx tsc -P tsconfig.json && node --test src/*.test.js"
+    "test": "npx tsc -P tsconfig.json && node --test src/*.test.js && ./test/all.sh"
   },
   "homepage": "https://8thwall.org",
   "bugs": {

--- a/apps/image-target-cli/src/BUILD
+++ b/apps/image-target-cli/src/BUILD
@@ -1,0 +1,51 @@
+load("//bzl/js:js.bzl", "js_library")
+
+js_library(
+    name = "apply",
+    srcs = [
+        "apply.js",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":constants",
+        ":crop",
+        ":image-data",
+        ":types",
+        ":unconify",
+    ],
+)
+
+js_library(
+    name = "types",
+    srcs = [
+        "types.ts",
+    ],
+)
+
+js_library(
+    name = "constants",
+    srcs = [
+        "constants.json",
+    ],
+)
+
+js_library(
+    name = "image-data",
+    srcs = [
+        "image-data.js",
+    ],
+)
+
+js_library(
+    name = "unconify",
+    srcs = [
+        "unconify.js",
+    ],
+)
+
+js_library(
+    name = "crop",
+    srcs = [
+        "crop.js",
+    ],
+)

--- a/apps/image-target-cli/src/apply.js
+++ b/apps/image-target-cli/src/apply.js
@@ -33,8 +33,8 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
     const originalImageData = new ImageData(baseMetadata.width, baseMetadata.height)
     originalImageData.data.set(await rawImage.clone().raw().toBuffer())
     const points = computePixelPointsFromRadius(
-      crop.geometry.topRadius,
-      crop.geometry.bottomRadius,
+      crop.properties.topRadius,
+      crop.properties.bottomRadius,
       baseMetadata.width
     )
     const geometryImageData = unconify(originalImageData, points, baseMetadata.width)
@@ -46,11 +46,11 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
         channels: 4,
       },
     })
-    if (crop.geometry.isRotated) {
+    if (crop.properties.isRotated) {
       geometryImage = geometryImage.rotate(90)
     }
 
-    metadata = crop.geometry.isRotated
+    metadata = crop.properties.isRotated
       ? {
         width: geometryImageData.height,
         height: geometryImageData.width,
@@ -59,7 +59,7 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
         width: geometryImageData.width,
         height: geometryImageData.height,
       }
-  } else if (crop.geometry.isRotated) {
+  } else if (crop.properties.isRotated) {
     originalImage = rawImage.clone().rotate(90)
     metadata = {width: baseMetadata.height, height: baseMetadata.width}
   } else {
@@ -67,7 +67,7 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
     metadata = baseMetadata
   }
 
-  const issues = validateCrop(crop.geometry, metadata)
+  const issues = validateCrop(crop.properties, metadata)
   if (issues.length) {
     throw new Error(`Invalid crop geometry:\n${issues.join('\n')}`)
   }
@@ -90,12 +90,11 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
   // Final JSON
   /** @type {import("./types").ImageTargetData} */
   const data = {
+    ...crop,
     // NOTE(christoph): This is a URL, not a relative path
     imagePath: `image-targets/${resources.luminanceImage}`,
     metadata: null,
     name,
-    type: crop.type,
-    properties: crop.geometry,
     resources,
     created: Date.now(),
     updated: Date.now(),
@@ -104,7 +103,7 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
   const dataPath = path.join(folder, `${name}.json`)
 
   const cropSourceImage = geometryImage || originalImage
-  const croppedImage = cropSourceImage.clone().extract(crop.geometry)
+  const croppedImage = cropSourceImage.clone().extract(crop.properties)
 
   const thumbnailImage = croppedImage
     .clone()
@@ -140,7 +139,7 @@ const applyCrop = async (rawImage, crop, folder, name, overwriteFiles) => {
     thumbnailImage.toFile(path.join(folder, resources.thumbnailImage)),
     luminanceImage.toFile(path.join(folder, resources.luminanceImage)),
     croppedImage.toFile(path.join(folder, resources.croppedImage)),
-    geometryImage
+    (geometryImage && resources.geometryImage)
       ? geometryImage.toFile(path.join(folder, resources.geometryImage))
       : null,
     fs.writeFile(dataPath, `${JSON.stringify(data, null, 2)}\n`),

--- a/apps/image-target-cli/src/interactive.js
+++ b/apps/image-target-cli/src/interactive.js
@@ -119,7 +119,7 @@ const selectCylindricalGeometry = async (rl, imageMetadata) => {
 /**
  * @param {CliInterface} rl
  * @param {ImageMetadata} imageMetadata
- * @returns {Promise<ConicalCropResult['geometry']>}
+ * @returns {Promise<ConicalCropResult['properties']>}
  */
 const selectConicalGeometry = async (rl, imageMetadata) => {
   const widerSide = await rl.choose('Which side of the cone is wider?', ['top', 'bottom'], true)
@@ -203,15 +203,15 @@ const selectGeometry = async (rl, imageMetadata) => {
     case 'flat':
       return {
         type: 'PLANAR',
-        geometry: await selectPlanarGeometry(rl, imageMetadata),
+        properties: await selectPlanarGeometry(rl, imageMetadata),
       }
     case 'cylinder':
       return {
         type: 'CYLINDER',
-        geometry: await selectCylindricalGeometry(rl, imageMetadata),
+        properties: await selectCylindricalGeometry(rl, imageMetadata),
       }
     case 'cone':
-      return {type: 'CONICAL', geometry: await selectConicalGeometry(rl, imageMetadata)}
+      return {type: 'CONICAL', properties: await selectConicalGeometry(rl, imageMetadata)}
     default:
       throw new Error(`Unknown type: ${type}`)
   }

--- a/apps/image-target-cli/src/types.ts
+++ b/apps/image-target-cli/src/types.ts
@@ -19,7 +19,6 @@ type ImageTargetData = CropResult & {
   created: number
   updated: number
 }
-
 interface CropGeometry {
   top: number
   left: number

--- a/apps/image-target-cli/src/types.ts
+++ b/apps/image-target-cli/src/types.ts
@@ -11,16 +11,15 @@ type ReferencedResources = {
   geometryImage?: string
 }
 
-type ImageTargetData = {
+type ImageTargetData = CropResult & {
   imagePath: string
   metadata: null
   name: string
-  type: 'PLANAR' | 'CYLINDER' | 'CONICAL'
-  properties: CropGeometry | CylinderCropGeometry | ConicalCropGeometry
   resources: ReferencedResources
   created: number
   updated: number
 }
+
 interface CropGeometry {
   top: number
   left: number
@@ -49,15 +48,15 @@ type ConicalCropGeometry = CylinderCropGeometry & {
 
  type PlanarCropResult = {
    type: 'PLANAR'
-   geometry: CropGeometry
+   properties: CropGeometry
  }
  type CylinderCropResult = {
    type: 'CYLINDER'
-   geometry: CylinderCropGeometry
+   properties: CylinderCropGeometry
  }
  type ConicalCropResult = {
    type: 'CONICAL'
-   geometry: ConicalCropGeometry
+   properties: ConicalCropGeometry
  }
 
  type CropResult =


### PR DESCRIPTION
## Context

Setup for https://github.com/8thwall/8thwall/issues/52

Defining `CropResult` as a subset of `ImageTargetData` makes things a bit nicer.

Going to be importing these files directly into bazel.

## Testing

- `./scripts/lint.sh` passes
- `npm run test` passes
