### PR TITLE
[xrhome] Update gallery filter for local targets

### DIFF
--- a/reality/cloud/xrhome/src/client/image-targets/actions.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/actions.ts
@@ -1,16 +1,19 @@
 import {
   SET_GALLERY_FILTER,
   ImageTargetFilterOptions,
+  RESET_GALLERY_FILTER,
+  ResetTargetsGalleryFilterAction,
+  SetTargetsGalleryFilterAction,
 } from './types'
 import type {DispatchifiedActions} from '../common/types/actions'
 import {dispatchify} from '../common'
-import {DEFAULT_FILTER_OPTIONS} from './reducer'
 
-const resetGalleryFilterOptionsForApp = (appUuid: string, galleryUuid: string) => ({
-  type: SET_GALLERY_FILTER,
+const resetGalleryFilterOptionsForApp = (
+  appUuid: string, galleryUuid: string
+): ResetTargetsGalleryFilterAction => ({
+  type: RESET_GALLERY_FILTER || 'IMAGE_TARGET/RESET_GALLERY_FILTER',
   appUuid,
   galleryUuid,
-  options: {...DEFAULT_FILTER_OPTIONS},
 })
 
 // TODO(christoph): Clean up
@@ -22,17 +25,12 @@ const noopAction = (name: string): any => () => () => {
 // Performs a fresh fetch after setting options.
 const setGalleryFilterOptionsForApp = (
   appUuid: string, galleryUuid: string, options: Partial<ImageTargetFilterOptions>
-) => (dispatch, getState) => {
-  dispatch({
-    type: SET_GALLERY_FILTER,
-    appUuid,
-    galleryUuid,
-    options: {
-      ...getState().imageTargets.targetInfoByApp[appUuid]?.galleryFilters,
-      ...options,
-    },
-  })
-}
+): SetTargetsGalleryFilterAction => ({
+  type: SET_GALLERY_FILTER,
+  appUuid,
+  galleryUuid,
+  options,
+})
 
 export const rawActions = {
   fetchSingleTargetForApp: noopAction('fetchSingleTargetForApp'),

--- a/reality/cloud/xrhome/src/client/image-targets/gallery-filters.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/gallery-filters.ts
@@ -1,0 +1,28 @@
+import type {IImageTarget} from '../common/types/models'
+import type {ImageTargetFilterOptions} from './types'
+
+const targetMatchesFilter = (target: IImageTarget, filter: ImageTargetFilterOptions): boolean => {
+  if (filter.nameLike) {
+    if (!target.name.includes(filter.nameLike)) {
+      return false
+    }
+  }
+
+  if (filter.type && filter.type.length) {
+    if (!filter.type.includes(target.type)) {
+      return false
+    }
+  }
+
+  if (filter.hasMetadata) {
+    if (!target.userMetadata) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export {
+  targetMatchesFilter,
+}

--- a/reality/cloud/xrhome/src/client/image-targets/gallery-filters.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/gallery-filters.ts
@@ -3,7 +3,8 @@ import type {ImageTargetFilterOptions} from './types'
 
 const targetMatchesFilter = (target: IImageTarget, filter: ImageTargetFilterOptions): boolean => {
   if (filter.nameLike) {
-    if (!target.name.includes(filter.nameLike)) {
+    const lowerFilter = filter.nameLike.toLowerCase()
+    if (!target.name.toLowerCase().includes(lowerFilter)) {
       return false
     }
   }

--- a/reality/cloud/xrhome/src/client/image-targets/reducer.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/reducer.ts
@@ -1,7 +1,7 @@
 import {
   AppImageTargetInfo,
   SET_GALLERY_FILTER, SetTargetsGalleryFilterAction, ImageTargetAction, ImageTargetMessage,
-  ImageTargetReduxState,
+  ImageTargetReduxState, ResetTargetsGalleryFilterAction, RESET_GALLERY_FILTER,
   ImageTargetFilterOptions,
   ImageTargetGallery,
 } from './types'
@@ -16,9 +16,7 @@ const initialState: ImageTargetReduxState = {
 const DEFAULT_FILTER_OPTIONS: ImageTargetFilterOptions = {
   nameLike: null,
   type: [],
-  metadata: [],
-  by: ['created'],
-  dir: ['desc'],
+  hasMetadata: false,
 }
 
 const DEFAULT_GALLERY: ImageTargetGallery = {
@@ -45,7 +43,7 @@ const getUpdateForAppState = (
 const filterGalleryTargets = (
   state: ImageTargetReduxState,
   action: SetTargetsGalleryFilterAction
-) => {
+): ImageTargetReduxState => {
   const {galleryUuid, appUuid, options} = action
   const galleries = state.targetInfoByApp[appUuid]?.galleries
   const update: ImageTargetGallery = galleries?.[galleryUuid] || DEFAULT_GALLERY
@@ -60,8 +58,25 @@ const filterGalleryTargets = (
   })
 }
 
+const resetGalleryFilter = (
+  state: ImageTargetReduxState,
+  action: ResetTargetsGalleryFilterAction
+): ImageTargetReduxState => {
+  const {galleryUuid, appUuid} = action
+  const galleries = state.targetInfoByApp[appUuid]?.galleries
+  return getUpdateForAppState(state, appUuid, {
+    galleries: {
+      ...galleries,
+      [galleryUuid]: {
+        filters: DEFAULT_FILTER_OPTIONS,
+      },
+    },
+  })
+}
+
 const actions: Record<ImageTargetMessage, ActionFunction> = {
   [SET_GALLERY_FILTER]: filterGalleryTargets,
+  [RESET_GALLERY_FILTER]: resetGalleryFilter,
 }
 
 const Reducer = (state = initialState, action: ImageTargetAction): ImageTargetReduxState => {

--- a/reality/cloud/xrhome/src/client/image-targets/types.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/types.ts
@@ -1,8 +1,12 @@
 import type {DeepReadonly} from 'ts-essentials'
 
+import type {ImageTargetType} from '../common/types/db'
+
 const SET_GALLERY_FILTER = 'IMAGE_TARGET/SET_GALLERY_FILTER'
+const RESET_GALLERY_FILTER = 'IMAGE_TARGET/RESET_GALLERY_FILTER'
 
  type ImageTargetMessage = typeof SET_GALLERY_FILTER
+  | typeof RESET_GALLERY_FILTER
 
  type ImageTargetStatus = 'loading-initial' | 'loading-additional' | 'loaded' | 'cleared'
 
@@ -14,18 +18,12 @@ interface AppImageTargetInfo extends DeepReadonly<{
   galleries: Record<string, ImageTargetGallery>
 }> {}
 
- type ImageTargetOrdering = 'created' | 'updated' | 'name'
- type ImageTargetOrderDirection = 'asc' | 'desc'
- type ImageTargetGeometryFilter = 'flat' | 'cylindrical' | 'conical'
- type ImageTargetFilterFlag = 'metadata'
- type ImageTargetFilterFlagValue = 'set' | 'unset' | 'true' | 'false'
+ type ImageTargetFilterFlag = 'hasMetadata'
 
 interface ImageTargetFilterOptions extends DeepReadonly<{
   nameLike: string | null
-  type: ImageTargetGeometryFilter[]
-  metadata: ImageTargetFilterFlagValue[]
-  by: ImageTargetOrdering[]
-  dir: ImageTargetOrderDirection[]
+  type: ImageTargetType[]
+  hasMetadata: boolean
 }> {}
 
 interface ImageTargetReduxState extends DeepReadonly<{
@@ -36,13 +34,21 @@ interface SetTargetsGalleryFilterAction {
   type: typeof SET_GALLERY_FILTER
   appUuid: string
   galleryUuid: string
-  options: ImageTargetFilterOptions
+  options: Partial<ImageTargetFilterOptions>
+}
+
+interface ResetTargetsGalleryFilterAction {
+  type: typeof RESET_GALLERY_FILTER
+  appUuid: string
+  galleryUuid: string
 }
 
  type ImageTargetAction = SetTargetsGalleryFilterAction
+  | ResetTargetsGalleryFilterAction
 
 export {
   SET_GALLERY_FILTER,
+  RESET_GALLERY_FILTER,
 }
 
 export type {
@@ -50,13 +56,10 @@ export type {
   ImageTargetMessage,
   ImageTargetStatus,
   AppImageTargetInfo,
-  ImageTargetOrdering,
-  ImageTargetOrderDirection,
-  ImageTargetGeometryFilter,
   ImageTargetFilterFlag,
-  ImageTargetFilterFlagValue,
   ImageTargetFilterOptions,
   ImageTargetReduxState,
   SetTargetsGalleryFilterAction,
   ImageTargetAction,
+  ResetTargetsGalleryFilterAction,
 }

--- a/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
@@ -82,8 +82,10 @@ const useGalleryTargets = (galleryUuid: string | undefined) => {
       ? selectTargetsGalleryFilterOptions(appKey, galleryUuid, s.imageTargets)
       : DEFAULT_FILTER_OPTIONS
   ))
-  // TODO(christoph): Filter based on gallery filters
-  return React.useMemo(() => targets.filter(t => targetMatchesFilter(t, filter)), [targets, filter])
+  return React.useMemo(
+    () => targets.filter(t => targetMatchesFilter(t, filter)),
+    [targets, filter]
+  )
 }
 
 const useImageTargetActions = () => {

--- a/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
@@ -16,6 +16,7 @@ import {selectTargetsGalleryFilterOptions} from './state-selectors'
 import {useSelector} from '../hooks'
 import {DEFAULT_FILTER_OPTIONS} from './reducer'
 import type {IImageTarget} from '../common/types/models'
+import {targetMatchesFilter} from './gallery-filters'
 
 const makeImageTargetTextureUrl = (
   appKey: string, target: ImageTargetData, type: TargetTextureType
@@ -51,7 +52,9 @@ const expandTargetData = (appKey: string, target: ImageTargetData): IImageTarget
 
 const fetchImageTargets = async (appKey: string): Promise<DeepReadonly<IImageTarget[]>> => {
   const {targets} = await listImageTargets(appKey)
-  return targets.map(target => expandTargetData(appKey, target))
+  return targets
+    .map(target => expandTargetData(appKey, target))
+    .sort((a, b) => b.created - a.created)
 }
 
 const useImageTargets = () => {
@@ -80,7 +83,7 @@ const useGalleryTargets = (galleryUuid: string | undefined) => {
       : DEFAULT_FILTER_OPTIONS
   ))
   // TODO(christoph): Filter based on gallery filters
-  return React.useMemo(() => targets, [targets, filter])
+  return React.useMemo(() => targets.filter(t => targetMatchesFilter(t, filter)), [targets, filter])
 }
 
 const useImageTargetActions = () => {

--- a/reality/cloud/xrhome/src/client/studio/image-target-browser.tsx
+++ b/reality/cloud/xrhome/src/client/studio/image-target-browser.tsx
@@ -1,7 +1,6 @@
 import React, {useEffect} from 'react'
 import {createUseStyles} from 'react-jss'
 import {useTranslation} from 'react-i18next'
-import type {DeepReadonly} from 'ts-essentials'
 
 import {useEnclosedApp} from '../apps/enclosed-app-context'
 import {useSelector} from '../hooks'
@@ -10,11 +9,10 @@ import imageTargetsActions from '../image-targets/actions'
 import useActions from '../common/use-actions'
 import {OptionalFilters, SearchBar, SearchToolbar} from './ui/search-bar'
 import type {
-  ImageTargetFilterFlagValue, ImageTargetFilterOptions, ImageTargetGeometryFilter,
+  ImageTargetFilterFlag,
 } from '../image-targets/types'
 import {combine} from '../common/styles'
 import {selectTargetsGalleryFilterOptions} from '../image-targets/state-selectors'
-import {DEFAULT_FILTER_OPTIONS} from '../image-targets/reducer'
 import {
   AddImageTargetButton, ImageTargetUploadInput, useImageTargetUpload,
 } from './image-target-upload'
@@ -26,6 +24,7 @@ import {ContextMenu, useContextMenuState} from './ui/context-menu'
 import FileUploadProgressBar from '../editor/file-upload-progress-bar'
 import {useStudioStateContext} from './studio-state-context'
 import {useGalleryTargets} from '../image-targets/use-image-targets'
+import type {ImageTargetType} from '../common/types/db'
 
 const useStyles = createUseStyles({
   targetsContainer: {
@@ -64,29 +63,25 @@ const useStyles = createUseStyles({
   },
 })
 
-type GeometryFilter = {type: ImageTargetGeometryFilter, label: string}
+type GeometryFilter = {type: ImageTargetType, label: string}
 const GEOMETRY_FILTERS: GeometryFilter[] = [{
-  type: 'flat',
+  type: 'PLANAR',
   label: 'file_browser.image_targets.flat',
 }, {
-  type: 'cylindrical',
+  type: 'CYLINDER',
   label: 'file_browser.image_targets.cylindrical',
 }, {
-  type: 'conical',
+  type: 'CONICAL',
   label: 'file_browser.image_targets.conical',
 }]
 
-type FlagKey = keyof {
-  [P in keyof ImageTargetFilterOptions as ImageTargetFilterOptions[P] extends
-  DeepReadonly<ImageTargetFilterFlagValue[]>? P : never]: any
-}
 type FlagFilter = {
-  type: FlagKey, label: string, enabledValue: ImageTargetFilterFlagValue
+  type: ImageTargetFilterFlag
+  label: string
 }
 const FLAG_FILTERS: FlagFilter[] = [{
-  type: 'metadata',
+  type: 'hasMetadata',
   label: 'file_browser.image_targets.metadata',
-  enabledValue: 'set',
 }]
 
 const IMAGE_TARGET_FILTERS = [
@@ -115,15 +110,15 @@ const StudioImageTargetBrowser: React.FC = () => {
   const searchValue = galleryOptions.nameLike || ''
   const filters = [
     ...galleryOptions.type,
-    ...FLAG_FILTERS.map(({type, enabledValue}) => (
-      galleryOptions[type].includes(enabledValue) ? type : null
+    ...FLAG_FILTERS.map(({type}) => (
+      galleryOptions[type] ? type : null
     )).filter(Boolean),
   ]
 
   const searching = searchValue.length > 0 || filters.length > 0
 
   const clearSearch = () => {
-    setGalleryFilterOptionsForApp(app.uuid, BROWSER_GALLERY_ID, DEFAULT_FILTER_OPTIONS)
+    resetGalleryFilterOptionsForApp(app.uuid, BROWSER_GALLERY_ID)
   }
 
   const setSearchValue = (value: string) => {
@@ -136,9 +131,9 @@ const StudioImageTargetBrowser: React.FC = () => {
     setGalleryFilterOptionsForApp(app.uuid, BROWSER_GALLERY_ID, {
       type: GEOMETRY_FILTERS.filter(({type}) => newFilters.includes(type)).map(({type}) => type),
       ...Object.fromEntries(
-        FLAG_FILTERS.map(({type, enabledValue}) => [
+        FLAG_FILTERS.map(({type}) => [
           type,
-          newFilters.includes(type) ? [enabledValue] : [],
+          newFilters.includes(type),
         ])
       ),
     })


### PR DESCRIPTION
## Context

Part of #52

We used to pass these parameters to the API, but we already load all the targets into memory so we can filter client side.

## Testing

- `npm run ts:check` passes
- `./scripts/lint.sh` passes
- Can filter by type
- Can filter by whether metadata is present
- Can filter by name (case insensitive)
- Can reset filter