### PR TITLE
[desktop] Add fallback logic for target metadata without resources specified

### DIFF
--- a/apps/desktop/app/image-targets/image-target-handler.ts
+++ b/apps/desktop/app/image-targets/image-target-handler.ts
@@ -116,8 +116,21 @@ const resolveImagePath = async (targetPath: string, type: TargetApi.TargetTextur
   const target = await readTarget(targetPath)
   const relativePath = extractImagePath(target, type)
   if (!relativePath) {
+    const extensionOptions = ['.jpg', '.png', '.jpeg']
+    const basePath = path.join(path.dirname(targetPath), `${target.name}_${type}`)
+    for (const extension of extensionOptions) {
+      try {
+        const fullPath = basePath + extension
+        // eslint-disable-next-line no-await-in-loop
+        await fs.stat(fullPath)
+        return fullPath
+      } catch (err: any) {
+        if (err.code !== 'ENOENT') {
+          throw err
+        }
+      }
+    }
     return null
-    // TODO(christoph): Add fallback heuristic for legacy image format
   }
   return path.join(path.dirname(targetPath), relativePath)
 }


### PR DESCRIPTION
## Context

Part of https://github.com/8thwall/8thwall/issues/52

We didn't have `resources` stored initially, so we need to search the filesystem for a target matching the expected format

## Testing

<img width="642" height="446" alt="Screenshot 2026-04-15 at 8 54 32 PM" src="https://github.com/user-attachments/assets/a9ffd910-0aa5-41f1-bbed-cf16c3b1e742" />


### Before

<img width="334" height="116" alt="Screenshot 2026-04-15 at 8 50 16 PM" src="https://github.com/user-attachments/assets/76c86157-88ae-45bc-8fc0-d619d3fe18d1" />


### After


<img width="288" height="167" alt="Screenshot 2026-04-15 at 8 57 05 PM" src="https://github.com/user-attachments/assets/2814e0b6-b1f1-43b1-880a-ef85a9f4ebb9" />


