### PR TITLE
[xrhome] Remove geometryTextureImageSrc from non-cone targets

### DIFF
--- a/reality/cloud/xrhome/src/client/common/types/models.ts
+++ b/reality/cloud/xrhome/src/client/common/types/models.ts
@@ -75,7 +75,7 @@ interface IImageTarget extends ImageTarget {
   originalImageSrc: string
   imageSrc: string
   thumbnailImageSrc: string
-  geometryTextureImageSrc: string
+  geometryTextureImageSrc: string | null
   appKey: string
 }
 

--- a/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
@@ -37,7 +37,9 @@ const expandTargetData = (appKey: string, target: ImageTargetData): IImageTarget
   appKey,
   originalImageSrc: makeImageTargetTextureUrl(appKey, target, 'original'),
   imageSrc: makeImageTargetTextureUrl(appKey, target, 'cropped'),
-  geometryTextureImageSrc: makeImageTargetTextureUrl(appKey, target, 'geometry'),
+  geometryTextureImageSrc: target.type === 'CONICAL'
+    ? makeImageTargetTextureUrl(appKey, target, 'geometry')
+    : null,
   thumbnailImageSrc: makeImageTargetTextureUrl(appKey, target, 'thumbnail'),
   uuid: target.name,
   userMetadata: target.metadata && (typeof target.metadata === 'string'


### PR DESCRIPTION
## Context

Part of https://github.com/8thwall/8thwall/issues/52

For showing the image outside the cropped region, we were using `geometryTextureImageSrc || originalImageSrc`. Not all generated targets contain a geometry (generally should just be conical), we can't always set a geometry URL that 404s if loaded.

## Testing

| Before | After |
| ------ | ------ |
|    <img width="554" height="354" alt="Screenshot 2026-04-16 at 4 17 22 PM" src="https://github.com/user-attachments/assets/18ae402d-9b2b-4d11-86e1-8ea6b9ef8819" /> |   <img width="466" height="276" alt="Screenshot 2026-04-16 at 4 18 36 PM" src="https://github.com/user-attachments/assets/e48dd5c8-58be-4c56-a0a9-4b365beb144c" /> |      