### PR TITLE
[desktop] Detect @8thwall/ecs npm package for metadata and migration status

### DIFF
--- a/apps/desktop/app/file-sync/project-handler.ts
+++ b/apps/desktop/app/file-sync/project-handler.ts
@@ -114,6 +114,37 @@ const getLocalProjectLocation = withErrorHandlingResponse(async (req: Request) =
   return recordLocalProject(savePath, 'v2')
 })
 
+const checkProjectMigrated = async (projectPath: string): Promise<boolean> => {
+  log.info('Checking project migrated: ', projectPath)
+  try {
+    const inlineRuntimeFolder = await fs.stat(path.join(projectPath, 'external/runtime'))
+    if (inlineRuntimeFolder.isDirectory()) {
+      log.info('Project has external/runtime folder: ', projectPath)
+      return true
+    }
+  } catch (err) {
+    log.info('Project has no external/runtime folder: ', err)
+    // No inline folder
+  }
+
+  try {
+    const packageJsonString = await fs.readFile(path.join(projectPath, 'package.json'), 'utf8')
+    const packageJsonData = JSON.parse(packageJsonString)
+    const packages = {...packageJsonData.dependencies, ...packageJsonData.devDependencies}
+    if (packages['@8thwall/ecs']) {
+      log.info('Project has @8thwall/ecs installed')
+      return true
+    }
+
+    log.info('Not installed', packages)
+  } catch (err) {
+    log.info('Project has no package.json: ', err)
+    // No package/invalid package
+  }
+
+  return false
+}
+
 const openDiskLocation = withErrorHandlingResponse(async () => {
   const projectPath = await locationPrompt()
 
@@ -146,12 +177,7 @@ const openDiskLocation = withErrorHandlingResponse(async () => {
     throw makeCodedError(`The provided path does not contain a valid project: ${projectPath}`, 409)
   }
 
-  let isMigrated = false
-  try {
-    isMigrated = (await fs.stat(path.join(projectPath, 'external/runtime'))).isDirectory()
-  } catch (error: any) {
-    // Not migrated
-  }
+  const isMigrated = await checkProjectMigrated(projectPath)
 
   return recordLocalProject(projectPath, isMigrated ? 'v2' : 'done')
 })
@@ -725,17 +751,26 @@ const getRuntimeMetadata = withErrorHandlingResponse(async (req: Request) => {
   if (!project) {
     throw makeCodedError('Project for appKey not found', 404)
   }
-  const runtimePath = path.join(project.location, 'external/runtime/metadata.json')
-  try {
-    const metadataContent = await fs.readFile(runtimePath, 'utf-8')
-    const metadata: RuntimeMetadata = JSON.parse(metadataContent)
-    return makeJsonResponse(metadata)
-  } catch (error: any) {
-    if (error.code === 'ENOENT') {
-      throw makeCodedError('Runtime metadata not found', 404)
+
+  const metadataPaths = [
+    'node_modules/@8thwall/ecs/metadata.json',
+    'external/runtime/metadata.json',
+  ]
+
+  for (const possiblePath of metadataPaths) {
+    const runtimePath = path.join(project.location, possiblePath)
+    log.info('Checking for metadata at:', runtimePath)
+    try {
+      const metadataContent = await fs.readFile(runtimePath, 'utf-8')
+      const metadata: RuntimeMetadata = JSON.parse(metadataContent)
+      return makeJsonResponse(metadata)
+    } catch (error: any) {
+      if (error.code !== 'ENOENT') {
+        throw error
+      }
     }
-    throw error
   }
+  throw makeCodedError('Runtime metadata not found', 404)
 })
 
 const handleProjectRuntimeMetadataRequest = (request: Request) => {

--- a/apps/desktop/app/file-sync/project-handler.ts
+++ b/apps/desktop/app/file-sync/project-handler.ts
@@ -115,15 +115,12 @@ const getLocalProjectLocation = withErrorHandlingResponse(async (req: Request) =
 })
 
 const checkProjectMigrated = async (projectPath: string): Promise<boolean> => {
-  log.info('Checking project migrated: ', projectPath)
   try {
     const inlineRuntimeFolder = await fs.stat(path.join(projectPath, 'external/runtime'))
     if (inlineRuntimeFolder.isDirectory()) {
-      log.info('Project has external/runtime folder: ', projectPath)
       return true
     }
   } catch (err) {
-    log.info('Project has no external/runtime folder: ', err)
     // No inline folder
   }
 
@@ -132,13 +129,9 @@ const checkProjectMigrated = async (projectPath: string): Promise<boolean> => {
     const packageJsonData = JSON.parse(packageJsonString)
     const packages = {...packageJsonData.dependencies, ...packageJsonData.devDependencies}
     if (packages['@8thwall/ecs']) {
-      log.info('Project has @8thwall/ecs installed')
       return true
     }
-
-    log.info('Not installed', packages)
   } catch (err) {
-    log.info('Project has no package.json: ', err)
     // No package/invalid package
   }
 
@@ -759,8 +752,8 @@ const getRuntimeMetadata = withErrorHandlingResponse(async (req: Request) => {
 
   for (const possiblePath of metadataPaths) {
     const runtimePath = path.join(project.location, possiblePath)
-    log.info('Checking for metadata at:', runtimePath)
     try {
+      // eslint-disable-next-line no-await-in-loop
       const metadataContent = await fs.readFile(runtimePath, 'utf-8')
       const metadata: RuntimeMetadata = JSON.parse(metadataContent)
       return makeJsonResponse(metadata)


### PR DESCRIPTION
## Context

Part of https://github.com/8thwall/8thwall/issues/51

To allow the desktop to recognize when the ecs runtime is installed through npm, we need to look for it when detecting the installation.

## Testing

With the following projects setup:
1. "Old desktop" project, with no external/runtime folder, and no @8thwall/ecs package installed
2. "External runtime" project, with an external/runtime folder
3. "NPM" project, with the runtime installed through @8thwall/ecs


<img width="1616" height="475" alt="Screenshot 2026-04-17 at 12 41 21 PM" src="https://github.com/user-attachments/assets/5b9b68ba-ee7d-44a3-b876-6f8b6dfa70dc" />

For the projects not requiring migration, opening them shows the "Kinematic" option which is only available with the `jolt` feature enabled, showing that metadata is loading:

<img width="339" height="227" alt="Screenshot 2026-04-17 at 12 40 13 PM" src="https://github.com/user-attachments/assets/b4dff9f5-1639-4116-ac6b-547dca738942" />

