### PR TITLE
[xrhome] Tweak image target query settings

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/index.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/index.tsx
@@ -26,6 +26,7 @@ const queryClient = new QueryClient()
 queryClient.setDefaultOptions({
   queries: {
     refetchOnWindowFocus: false,
+    networkMode: 'always',
   },
 })
 

--- a/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
+++ b/reality/cloud/xrhome/src/client/image-targets/use-image-targets.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import {useQuery, useQueryClient, useSuspenseQuery} from '@tanstack/react-query'
+import {queryOptions, useQuery, useQueryClient, useSuspenseQuery} from '@tanstack/react-query'
 
 import {
   CropResult, GetTargetTextureParams, ImageTargetData, TargetTextureType,
@@ -17,6 +17,7 @@ import {useSelector} from '../hooks'
 import {DEFAULT_FILTER_OPTIONS} from './reducer'
 import type {IImageTarget} from '../common/types/models'
 import {targetMatchesFilter} from './gallery-filters'
+import {MILLISECONDS_PER_SECOND} from '../../shared/time-utils'
 
 const makeImageTargetTextureUrl = (
   appKey: string, target: ImageTargetData, type: TargetTextureType
@@ -59,21 +60,22 @@ const fetchImageTargets = async (appKey: string): Promise<DeepReadonly<IImageTar
     .sort((a, b) => b.created - a.created)
 }
 
+const getTargetsQuery = (appKey: string) => queryOptions({
+  queryKey: ['image-targets', appKey],
+  queryFn: () => fetchImageTargets(appKey),
+  staleTime: MILLISECONDS_PER_SECOND * 10,
+  refetchInterval: MILLISECONDS_PER_SECOND * 60,
+  refetchOnWindowFocus: true,
+})
+
 const useImageTargets = () => {
   const appKey = useEnclosedAppKey()
-
-  return useSuspenseQuery({
-    queryKey: ['image-targets', appKey],
-    queryFn: () => fetchImageTargets(appKey),
-  }).data
+  return useSuspenseQuery(getTargetsQuery(appKey)).data
 }
 
 const useImageTargetsOrLoading = () => {
   const appKey = useEnclosedAppKey()
-  return useQuery({
-    queryKey: ['image-targets', appKey],
-    queryFn: () => fetchImageTargets(appKey),
-  })
+  return useQuery(getTargetsQuery(appKey))
 }
 
 const useGalleryTargets = (galleryUuid: string | undefined) => {
@@ -95,7 +97,7 @@ const useImageTargetActions = () => {
   const client = useQueryClient()
   return React.useMemo(() => {
     const refresh = () => {
-      client.invalidateQueries({queryKey: ['image-targets', appKey]})
+      client.invalidateQueries(getTargetsQuery(appKey))
     }
 
     const deleteTarget = async (name: string) => {

--- a/reality/cloud/xrhome/src/client/studio/file-browser.tsx
+++ b/reality/cloud/xrhome/src/client/studio/file-browser.tsx
@@ -334,7 +334,9 @@ const FileBrowser: React.FC<IFileBrowser> = ({
             {currentSection === 'files' && filesList}
             {currentSection === 'prefabs' && <PrefabsList />}
             {BuildIf.STUDIO_IMAGE_TARGETS_20260210 && currentSection === 'imageTargets' &&
-              <StudioImageTargetBrowser />
+              <React.Suspense fallback={<div><Loader /></div>}>
+                <StudioImageTargetBrowser />
+              </React.Suspense>
             }
             {BuildIf.STUDIO_ASSET_LAB_20260209 && currentSection === 'assetLab' &&
               <React.Suspense fallback={<div><Loader animateSpinnerColor /></div>}>


### PR DESCRIPTION
## Context

Part of #52 

## Testing

- Switching between targets does not refetch the list
- Switching to the image target resources tab doesn't trigger a full screen load state
- Targets are refetched periodically and when returning to the program