### PR TITLE
[desktop] Update packaging options for sharp

### DIFF
--- a/apps/desktop/builder.config.ts
+++ b/apps/desktop/builder.config.ts
@@ -74,6 +74,8 @@ export default {
   asar: true,
   asarUnpack: [
     '**/node_modules/better-sqlite3/**/*',
+    '**/node_modules/sharp/**/*',
+    '**/node_modules/@img/**/*',
   ],
   generateUpdatesFilesForAllChannels: true,
   mac: {

--- a/apps/desktop/tools/publish-release.sh
+++ b/apps/desktop/tools/publish-release.sh
@@ -8,8 +8,11 @@ npm ci --legacy-peer-deps
 BUILDIF_FLAG_LEVEL=launch npm run dist:desktop
 
 cd $ROOT/apps/desktop
-npm ci
 TS=$(date +%Y%m%d%H%M)
 npm version 1.0.$TS --no-git-tag-version
-RELEASE=true npm run publish:prod:mac
+
+npm ci --os=win32 --cpu=x64
 RELEASE=true npm run publish:prod:win
+
+npm ci
+RELEASE=true npm run publish:prod:mac


### PR DESCRIPTION
## Context

Part of #52 

https://sharp.pixelplumbing.com/install/#cross-platform

## Testing

When installed on windows:

### Before

Sharp complained about missing native packages

### After

Can create image targets through the desktop app