### PR TITLE
[xrhome] Bust metadata cache after completing setup

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
+++ b/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
@@ -2,13 +2,13 @@ import {useSuspenseQuery} from '@tanstack/react-query'
 
 import useCurrentApp from '../../common/use-current-app'
 import {getRuntimeMetadata} from '../local-sync-api'
-import {useLocalSyncContext} from '../local-sync-context'
+import {useMaybeLocalSyncContext} from '../local-sync-context'
 
 const useRuntimeMetadata = () => {
   const {appKey} = useCurrentApp()
-  const local = useLocalSyncContext()
+  const local = useMaybeLocalSyncContext()
   return useSuspenseQuery({
-    queryKey: ['runtimeMetadata', local.localBuildUrl],
+    queryKey: ['runtimeMetadata', local?.localBuildUrl],
     queryFn: () => getRuntimeMetadata(appKey),
   }).data
 }

--- a/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
+++ b/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
@@ -2,11 +2,13 @@ import {useSuspenseQuery} from '@tanstack/react-query'
 
 import useCurrentApp from '../../common/use-current-app'
 import {getRuntimeMetadata} from '../local-sync-api'
+import {useLocalSyncContext} from '../local-sync-context'
 
 const useRuntimeMetadata = () => {
   const {appKey} = useCurrentApp()
+  const local = useLocalSyncContext()
   return useSuspenseQuery({
-    queryKey: ['runtimeMetadata'],
+    queryKey: ['runtimeMetadata', local.localBuildUrl],
     queryFn: () => getRuntimeMetadata(appKey),
   }).data
 }


### PR DESCRIPTION
## Context

Follow up to #74 

Once watch-local succeeds, bust the cache on the runtime metadata. This is a workaround for runtime metadata not being available until npm install is finished, since before then, node_modules/@8thwall/ecs/metadata.json isn't present. It would only affect new projects.

## Testing

Runtime metadata initially is fetched as not found, and tanstack query retries a few times. Then after npm install finishes, and the server starts, the changed localUrl triggers a refetch which succeeds. 

<img width="564" height="94" alt="Screenshot 2026-04-21 at 3 32 37 PM" src="https://github.com/user-attachments/assets/a25741c4-29de-4f30-86e7-07b16225307c" />

