### PR TITLE
[xrhome] Add appKey to runtimeMetadata queryKey

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
+++ b/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
@@ -8,7 +8,7 @@ const useRuntimeMetadata = () => {
   const {appKey} = useCurrentApp()
   const local = useMaybeLocalSyncContext()
   return useSuspenseQuery({
-    queryKey: ['runtimeMetadata', local?.localBuildUrl],
+    queryKey: ['runtimeMetadata', appKey, local?.localBuildUrl],
     queryFn: () => getRuntimeMetadata(appKey),
   }).data
 }


### PR DESCRIPTION
## Context

This was missing even though we were passing `appKey` into `getRuntimeMetadata` which could lead to desync.

