### PR TITLE
[desktop] Fix missing asset configuration for new project

### DIFF
--- a/apps/desktop/new-project/config/webpack.config.js
+++ b/apps/desktop/new-project/config/webpack.config.js
@@ -45,6 +45,11 @@ const config = {
           to: path.join(distPath, 'external/xr'),
         },
         {
+          from: path.join(srcPath, 'assets'),
+          to: path.join(distPath, 'assets'),
+          noErrorOnMissing: true,
+        },
+        {
           from: path.join(rootPath, 'image-targets'),
           to: path.join(distPath, 'image-targets'),
           noErrorOnMissing: true,


### PR DESCRIPTION
## Context

Introduced in https://github.com/8thwall/8thwall/pull/75

## Testing

- Dev builds assets work
- Published builds contain the assets folder

<img width="406" height="81" alt="Screenshot 2026-04-22 at 12 05 20 PM" src="https://github.com/user-attachments/assets/3b32b8ac-d2ed-4f88-954d-af9805c50717" />


