### PR TITLE
[desktop] Add recommendation to fix missing asset configuration

### DIFF
--- a/apps/desktop/app/file-sync/project-handler-types.ts
+++ b/apps/desktop/app/file-sync/project-handler-types.ts
@@ -22,7 +22,7 @@ type IMoveProjectParams = z.infer<typeof MoveProjectParams>
 
 const FixConfigParams = z.object({
   appKey: z.string(),
-  fix: z.enum(['inject']),
+  fix: z.enum(['inject', 'copy-plugin']),
 })
 
 type IFixConfigParams = z.infer<typeof FixConfigParams>

--- a/apps/desktop/app/file-sync/project-handler.ts
+++ b/apps/desktop/app/file-sync/project-handler.ts
@@ -786,6 +786,45 @@ const GOOD_INJECT_CONFIG = `new HtmlWebpackPlugin({
       inject: false,
     })`
 
+const BAD_COPY_PLUGIN_CONFIG = `\
+      patterns: [
+        {
+          from: path.join(rootPath, 'node_modules/@8thwall/ecs/dist'),
+          to: path.join(distPath, 'external/runtime'),
+        },
+        {
+          from: path.join(rootPath, 'node_modules/@8thwall/engine-binary/dist'),
+          to: path.join(distPath, 'external/xr'),
+        },
+        {
+          from: path.join(rootPath, 'image-targets'),
+          to: path.join(distPath, 'image-targets'),
+          noErrorOnMissing: true,
+        },
+      ],`
+
+const GOOD_COPY_PLUGIN_CONFIG = `\
+      patterns: [
+        {
+          from: path.join(rootPath, 'node_modules/@8thwall/ecs/dist'),
+          to: path.join(distPath, 'external/runtime'),
+        },
+        {
+          from: path.join(rootPath, 'node_modules/@8thwall/engine-binary/dist'),
+          to: path.join(distPath, 'external/xr'),
+        },
+        {
+          from: path.join(srcPath, 'assets'),
+          to: path.join(distPath, 'assets'),
+          noErrorOnMissing: true,
+        },
+        {
+          from: path.join(rootPath, 'image-targets'),
+          to: path.join(distPath, 'image-targets'),
+          noErrorOnMissing: true,
+        },
+      ],`
+
 const WEBPACK_CONFIG_PATH = 'config/webpack.config.js'
 
 const getProjectConfig = withErrorHandlingResponse(async (req: Request) => {
@@ -805,15 +844,17 @@ const getProjectConfig = withErrorHandlingResponse(async (req: Request) => {
   }
 
   let needsInjectFix = false
+  let needsCopyPluginFix = false
   try {
     const configPath = path.join(project.location, WEBPACK_CONFIG_PATH)
     const configContent = await fs.readFile(configPath, 'utf-8')
     needsInjectFix = configContent.includes(BAD_INJECT_CONFIG)
+    needsCopyPluginFix = configContent.includes(BAD_COPY_PLUGIN_CONFIG)
   } catch (error) {
     // Ignore
   }
 
-  return makeJsonResponse({needsInjectFix})
+  return makeJsonResponse({needsInjectFix, needsCopyPluginFix})
 })
 
 const modifyProjectConfig = withErrorHandlingResponse(async (req: Request) => {
@@ -834,6 +875,13 @@ const modifyProjectConfig = withErrorHandlingResponse(async (req: Request) => {
       const configPath = path.join(project.location, WEBPACK_CONFIG_PATH)
       const configContent = await fs.readFile(configPath, 'utf-8')
       const fixedContent = configContent.replace(BAD_INJECT_CONFIG, GOOD_INJECT_CONFIG)
+      await fs.writeFile(configPath, fixedContent, 'utf-8')
+      break
+    }
+    case 'copy-plugin': {
+      const configPath = path.join(project.location, WEBPACK_CONFIG_PATH)
+      const configContent = await fs.readFile(configPath, 'utf-8')
+      const fixedContent = configContent.replace(BAD_COPY_PLUGIN_CONFIG, GOOD_COPY_PLUGIN_CONFIG)
       await fs.writeFile(configPath, fixedContent, 'utf-8')
       break
     }

--- a/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
+++ b/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
@@ -731,6 +731,7 @@
   "recommendation_box.modal_title": "Review Suggested Replacements",
   "recommendation_box.update_references": "Update references",
   "recommendation_box.inject_message": "This project is missing a required configuration change in config/webpack.config.js.",
+  "recommendation_box.copy_plugin_message": "Asset configuration was mistakenly left out of the project template in config/webpack.config.js.",
   "recommendation_box.fix": "Apply Fix",
   "recommendation_box.dismiss": "Dismiss",
   "reflection.menu.label.url": "URL",

--- a/reality/cloud/xrhome/src/client/studio/local-sync-api.ts
+++ b/reality/cloud/xrhome/src/client/studio/local-sync-api.ts
@@ -321,14 +321,13 @@ const checkConfigStatus = (appKey: string) => {
 
   })
 
-  return fetchJson<{needsInjectFix: boolean}>(
+  return fetchJson<{needsInjectFix: boolean, needsCopyPluginFix: boolean}>(
     `${API}/project/config?${params}`, {method: 'GET'}
   )
 }
 
-const applyProjectConfigFix = (appKey: string, fix: 'inject') => {
+const applyProjectConfigFix = (appKey: string, fix: 'inject' | 'copy-plugin') => {
   const params = new URLSearchParams({
-
     appKey,
     fix,
   })

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import {createUseStyles} from 'react-jss'
 import {useTranslation} from 'react-i18next'
 
+import {queryOptions, useQueryClient, useSuspenseQuery} from '@tanstack/react-query'
+
 import {useSceneContext} from './scene-context'
 import {useCurrentGit} from '../git/hooks/use-current-git'
 import {isAssetPath} from '../common/editor-files'
@@ -21,6 +23,7 @@ import {
 import {useAbandonableEffect} from '../hooks/abandonable-effect'
 import useCurrentApp from '../common/use-current-app'
 import {useLocalSyncContext} from './local-sync-context'
+import {useEnclosedAppKey} from '../apps/enclosed-app-context'
 
 const useStyles = createUseStyles({
   recommendationBox: {
@@ -116,15 +119,24 @@ const AssetBundleRecommendation = () => {
   )
 }
 
+const getProjectConfigStatusQuery = (appKey: string) => queryOptions({
+  queryKey: ['project-config', appKey],
+  queryFn: () => checkConfigStatus(appKey),
+})
+
+const useProjectConfigStatus = () => {
+  const appKey = useEnclosedAppKey()
+  return useSuspenseQuery(getProjectConfigStatusQuery(appKey)).data
+}
+
 const WebpackInjectFixRecommendation = () => {
   const {t} = useTranslation(['cloud-studio-pages', 'common'])
-  const [visible, setVisible] = React.useState(false)
   const {appKey} = useCurrentApp()
   const localSyncContext = useLocalSyncContext()
-  useAbandonableEffect(async (abandon) => {
-    const {needsInjectFix} = await abandon(checkConfigStatus(appKey))
-    setVisible(needsInjectFix)
-  }, [appKey])
+  const {needsInjectFix} = useProjectConfigStatus()
+  const queryClient = useQueryClient()
+  const [dismissed, setDismissed] = React.useState(false)
+  const visible = needsInjectFix && !dismissed
 
   if (!visible) {
     return null
@@ -138,12 +150,47 @@ const WebpackInjectFixRecommendation = () => {
           <BoldButton onClick={async () => {
             await applyProjectConfigFix(appKey, 'inject')
             await localSyncContext.restartServer()
-            setVisible(false)
+            queryClient.invalidateQueries(getProjectConfigStatusQuery(appKey))
           }}
           >
             {t('recommendation_box.fix')}
           </BoldButton>
-          <BoldButton onClick={() => setVisible(false)}>
+          <BoldButton onClick={() => setDismissed(true)}>
+            {t('recommendation_box.dismiss')}
+          </BoldButton>
+        </SpaceBetween>
+      </SpaceBetween>
+    </StaticBanner>
+  )
+}
+
+const CopyPluginFixRecommendation = () => {
+  const {t} = useTranslation(['cloud-studio-pages', 'common'])
+  const {appKey} = useCurrentApp()
+  const localSyncContext = useLocalSyncContext()
+  const {needsCopyPluginFix} = useProjectConfigStatus()
+  const queryClient = useQueryClient()
+  const [dismissed, setDismissed] = React.useState(false)
+  const visible = needsCopyPluginFix && !dismissed
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <StaticBanner type='warning'>
+      <SpaceBetween direction='vertical'>
+        {t('recommendation_box.copy_plugin_message')}
+        <SpaceBetween>
+          <BoldButton onClick={async () => {
+            await applyProjectConfigFix(appKey, 'copy-plugin')
+            await localSyncContext.restartServer()
+            queryClient.invalidateQueries(getProjectConfigStatusQuery(appKey))
+          }}
+          >
+            {t('recommendation_box.fix')}
+          </BoldButton>
+          <BoldButton onClick={() => setDismissed(true)}>
             {t('recommendation_box.dismiss')}
           </BoldButton>
         </SpaceBetween>
@@ -153,10 +200,11 @@ const WebpackInjectFixRecommendation = () => {
 }
 
 const RecommendationBox = () => (
-  <>
+  <React.Suspense fallback={null}>
     <AssetBundleRecommendation />
     <WebpackInjectFixRecommendation />
-  </>
+    <CopyPluginFixRecommendation />
+  </React.Suspense>
 )
 
 export {RecommendationBox}

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import {createUseStyles} from 'react-jss'
 import {useTranslation} from 'react-i18next'
-
-import {queryOptions, useQueryClient, useSuspenseQuery} from '@tanstack/react-query'
+import {queryOptions, useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {useSceneContext} from './scene-context'
 import {useCurrentGit} from '../git/hooks/use-current-git'
@@ -20,10 +19,9 @@ import {StandardModalHeader} from '../ui/components/standard-modal-header'
 import {
   applyProjectConfigFix, checkConfigStatus,
 } from './local-sync-api'
-import {useAbandonableEffect} from '../hooks/abandonable-effect'
 import useCurrentApp from '../common/use-current-app'
 import {useLocalSyncContext} from './local-sync-context'
-import {useEnclosedAppKey} from '../apps/enclosed-app-context'
+import {MILLISECONDS_PER_HOUR} from '../../shared/time-utils'
 
 const useStyles = createUseStyles({
   recommendationBox: {
@@ -122,18 +120,14 @@ const AssetBundleRecommendation = () => {
 const getProjectConfigStatusQuery = (appKey: string) => queryOptions({
   queryKey: ['project-config', appKey],
   queryFn: () => checkConfigStatus(appKey),
+  staleTime: MILLISECONDS_PER_HOUR,
 })
-
-const useProjectConfigStatus = () => {
-  const appKey = useEnclosedAppKey()
-  return useSuspenseQuery(getProjectConfigStatusQuery(appKey)).data
-}
 
 const WebpackInjectFixRecommendation = () => {
   const {t} = useTranslation(['cloud-studio-pages', 'common'])
   const {appKey} = useCurrentApp()
   const localSyncContext = useLocalSyncContext()
-  const {needsInjectFix} = useProjectConfigStatus()
+  const needsInjectFix = useQuery(getProjectConfigStatusQuery(appKey)).data?.needsInjectFix
   const queryClient = useQueryClient()
   const [dismissed, setDismissed] = React.useState(false)
   const visible = needsInjectFix && !dismissed
@@ -168,7 +162,7 @@ const CopyPluginFixRecommendation = () => {
   const {t} = useTranslation(['cloud-studio-pages', 'common'])
   const {appKey} = useCurrentApp()
   const localSyncContext = useLocalSyncContext()
-  const {needsCopyPluginFix} = useProjectConfigStatus()
+  const needsCopyPluginFix = useQuery(getProjectConfigStatusQuery(appKey)).data?.needsCopyPluginFix
   const queryClient = useQueryClient()
   const [dismissed, setDismissed] = React.useState(false)
   const visible = needsCopyPluginFix && !dismissed
@@ -200,11 +194,11 @@ const CopyPluginFixRecommendation = () => {
 }
 
 const RecommendationBox = () => (
-  <React.Suspense fallback={null}>
+  <>
     <AssetBundleRecommendation />
     <WebpackInjectFixRecommendation />
     <CopyPluginFixRecommendation />
-  </React.Suspense>
+  </>
 )
 
 export {RecommendationBox}


### PR DESCRIPTION
## Context

This automatically applies the fix from https://github.com/8thwall/8thwall/pull/91 to existing projects created in the last day.

## Testing

<img width="803" height="276" alt="Screenshot 2026-04-22 at 12 02 43 PM" src="https://github.com/user-attachments/assets/631f7db1-6a1b-4ed5-9a21-74d38e2040f8" />

When applied on a project with the bad config: 

<img width="680" height="408" alt="Screenshot 2026-04-22 at 12 07 25 PM" src="https://github.com/user-attachments/assets/947caeb9-07e3-4d0c-abf7-ca7c55188078" />

