### PR TITLE
[desktop] Simplify preferences handler routing

### DIFF
--- a/apps/desktop/app/preferences/BUILD
+++ b/apps/desktop/app/preferences/BUILD
@@ -13,6 +13,7 @@ js_library(
         "//apps/desktop:errors",
         "//apps/desktop:json-response",
         "//apps/desktop:local-preferences",
+        "//apps/desktop:requests",
         "//apps/desktop/app/preferences:code-editor",
         "//reality/shared/desktop:preferences-types",
     ],

--- a/apps/desktop/app/preferences/preferences-handler.ts
+++ b/apps/desktop/app/preferences/preferences-handler.ts
@@ -63,7 +63,10 @@ const handleGetInstalledPrograms: RequestHandler = async () => {
 }
 
 const handlePreferencesRequest = withErrorHandlingResponse(branches({
-  '/current': methods({GET: handleGetPreferences, PATCH: handlePatchPreferences}),
+  '/current': methods({
+    GET: handleGetPreferences,
+    PATCH: handlePatchPreferences,
+  }),
   '/installed-programs': methods({GET: handleGetInstalledPrograms}),
   '/choose-editor': methods({POST: handleChooseEditor}),
 }))

--- a/apps/desktop/app/preferences/preferences-handler.ts
+++ b/apps/desktop/app/preferences/preferences-handler.ts
@@ -7,6 +7,7 @@ import {makeJsonResponse} from '../../json-response'
 import {getPreference, setPreference} from '../../local-preferences'
 import {withErrorHandlingResponse} from '../../errors'
 import {getAvailableEditors} from './code-editor'
+import {branches, methods, RequestHandler} from '../../requests'
 
 const loadPreferences = (): HubPreferences => {
   const codeEditorPath = getPreference('codeEditorProgram') || ''
@@ -17,11 +18,11 @@ const loadPreferences = (): HubPreferences => {
   }
 }
 
-const handleGetPreferences = withErrorHandlingResponse((): Response => (
+const handleGetPreferences: RequestHandler = () => (
   makeJsonResponse(loadPreferences())
-))
+)
 
-const handlePatchPreferences = withErrorHandlingResponse(async (request) => {
+const handlePatchPreferences: RequestHandler = async (request) => {
   const body = await request.json()
   const {codeEditorPath, firstTimeStatus, theme} = body as Partial<HubPreferences>
 
@@ -38,9 +39,9 @@ const handlePatchPreferences = withErrorHandlingResponse(async (request) => {
   }
 
   return makeJsonResponse({})
-})
+}
 
-const handleChooseEditor = withErrorHandlingResponse(async () => {
+const handleChooseEditor: RequestHandler = async () => {
   const returnValue = await dialog.showOpenDialog({
     properties: ['openFile'],
   })
@@ -49,29 +50,9 @@ const handleChooseEditor = withErrorHandlingResponse(async () => {
   }
   setPreference('codeEditorProgram', returnValue.filePaths[0])
   return makeJsonResponse({})
-})
-
-const handleChooseEditorRequest = (request: Request) => {
-  switch (request.method) {
-    case 'POST':
-      return handleChooseEditor(request)
-    default:
-      return new Response('Not found', {status: 404})
-  }
 }
 
-const handleBasePreferencesRequest = (request: Request) => {
-  switch (request.method) {
-    case 'GET':
-      return handleGetPreferences(request)
-    case 'PATCH':
-      return handlePatchPreferences(request)
-    default:
-      return new Response('Not found', {status: 404})
-  }
-}
-
-const handleGetInstalledPrograms = withErrorHandlingResponse(async (): Promise<Response> => {
+const handleGetInstalledPrograms: RequestHandler = async () => {
   const availableEditors = await getAvailableEditors()
 
   const state: InstalledPrograms = {
@@ -79,35 +60,13 @@ const handleGetInstalledPrograms = withErrorHandlingResponse(async (): Promise<R
   }
 
   return makeJsonResponse(state)
-})
-
-const handleInstalledProgramsRequest = (request: Request) => {
-  switch (request.method) {
-    case 'GET':
-      return handleGetInstalledPrograms(request)
-    default:
-      return new Response('Not found', {status: 404})
-  }
 }
 
-const handlePreferencesRequest = (request: Request) => {
-  const requestUrl = new URL(request.url)
-  const {pathname} = requestUrl
-
-  switch (pathname) {
-    case '/current':
-      return handleBasePreferencesRequest(request)
-    case '/installed-programs':
-      return handleInstalledProgramsRequest(request)
-    case '/choose-editor':
-      return handleChooseEditorRequest(request)
-    default: {
-      // eslint-disable-next-line no-console
-      console.error('Unknown preferences request:', pathname)
-      return new Response('Not Found', {status: 404})
-    }
-  }
-}
+const handlePreferencesRequest = withErrorHandlingResponse(branches({
+  '/current': methods({GET: handleGetPreferences, PATCH: handlePatchPreferences}),
+  '/installed-programs': methods({GET: handleGetInstalledPrograms}),
+  '/choose-editor': methods({POST: handleChooseEditor}),
+}))
 
 export {
   handlePreferencesRequest,


### PR DESCRIPTION
## Context

Uses the handlers defined in https://github.com/8thwall/8thwall/pull/55

## Testing

- Can load and save preferences
- Lint and builds pass