### PR TITLE
[desktop] Fix zod validation for image target name update

### DIFF
--- a/apps/desktop/app/image-targets/image-target-types.ts
+++ b/apps/desktop/app/image-targets/image-target-types.ts
@@ -72,10 +72,7 @@ const UpdateTargetRequest = z.object({
   name: z.string().nonempty(),
   metadata: z.unknown(),
 }).partial()
-  .and(CropResult.or(z.object({
-    type: z.never(),
-    properties: z.never(),
-  })))
+  .and(CropResult.or(z.object({})))
 
 export {
   ListTargetsParams,


### PR DESCRIPTION
## Context

Closes https://github.com/8thwall/8thwall/issues/93

I was trying to do some zod gymnastics to avoid the ts-ignore here: https://github.com/8thwall/8thwall/blob/8a7264537b89dd0a1e665f269b609ded9ba7a956/apps/desktop/app/image-targets/image-target-handler.ts#L259, but I guess I made the type too strict by accident.

## Testing

### Before
<img width="561" height="355" alt="Screenshot 2026-04-27 at 10 15 34 AM" src="https://github.com/user-attachments/assets/40a883ed-b25e-44c4-9a31-3321ac28be94" />

### After

Can rename from the left hand list, and also re-crop/rename/update metadata from the right hand configurator
