### PR TITLE
[desktop] Fix sharp packaging error

### DIFF
--- a/apps/desktop/tools/publish-release.sh
+++ b/apps/desktop/tools/publish-release.sh
@@ -14,5 +14,6 @@ npm version 1.0.$TS --no-git-tag-version
 npm ci --os=win32 --cpu=x64
 RELEASE=true npm run publish:prod:win
 
-npm ci
+npm ci --cpu=arm64
+npm i --cpu=x64
 RELEASE=true npm run publish:prod:mac


### PR DESCRIPTION
## Context

Closes #95 

I attempted to do something with `beforeBuild` but it caused:

<img width="523" height="395" alt="Screenshot 2026-04-27 at 2 47 03 PM" src="https://github.com/user-attachments/assets/92eb0b46-7d22-4831-8544-618630357bc1" />

(on both x64 and arm64)

<details><summary>full snippet</summary>

```
  beforeBuild: async (context: {arch: string, platform: {nodeName: string}}) => {
    const execFileAsync = promisify(child_process.execFile)
    console.log('installing with', context.platform.nodeName, context.arch)
    console.log(process.cwd())
    await execFileAsync('npm', [
      'install',
      'sharp',
      '--os', context.platform.nodeName,
      '--cpu', context.arch])
    console.log(await fs.readdir('node_modules/@img'))
    console.log(await fs.readdir('node_modules/sharp'))
  },
```
</details>

Unfortunately it seems like we're going to have to take the hit of shipping both `sharp-darwin-arm64` and `sharp-darwin-x64` to both builds for now. 

## Testing

- Can create image targets on both x64 and arm64 macs


