### PR TITLE
[xrhome] Remove unneeded preview window types

### DIFF
--- a/reality/cloud/xrhome/src/client/common/app-preview-window-context.tsx
+++ b/reality/cloud/xrhome/src/client/common/app-preview-window-context.tsx
@@ -3,18 +3,12 @@ import React, {useRef} from 'react'
 type AppPreviewWindowContextValue = {
   getInlinePreviewWindow: () => Window | null
   setInlinePreviewWindow: (inlinePreviewWindow: Window) => void
-  getFramedPreviewWindow: () => Window | null
-  setFramedPreviewWindow: (framedPreviewWindow: Window) => void
-  getPreviewWindow: () => Window | null
-  setPreviewWindow: (previewWindow: Window) => void
 }
 
 const AppPreviewWindowContext = React.createContext<AppPreviewWindowContextValue>(null)
 
 const AppPreviewWindowContextProvider: React.FC<React.PropsWithChildren> = ({children}) => {
   const inlinePreviewWindowRef = useRef<Window | null>(null)
-  const framedPreviewWindowRef = useRef<Window | null>(null)
-  const previewWindowRef = useRef<Window | null>(null)
 
   /**
    * Check if the window has been closed, and update it. Otherwise just return the saved reference.
@@ -34,24 +28,10 @@ const AppPreviewWindowContextProvider: React.FC<React.PropsWithChildren> = ({chi
 
   // eslint-disable-next-line max-len
   const getAndMaybeUpdateInlinePreviewWindow = (): Window => getAndMaybeUpdateWindowRef(inlinePreviewWindowRef)
-
-  // eslint-disable-next-line max-len
-  const getAndMaybeUpdateFramedPreviewWindow = (): Window => getAndMaybeUpdateWindowRef(framedPreviewWindowRef)
-
-  const getAndMaybeUpdatePreviewWindow = (): Window => getAndMaybeUpdateWindowRef(previewWindowRef)
-
   const ctxValue = {
     getInlinePreviewWindow: getAndMaybeUpdateInlinePreviewWindow,
     setInlinePreviewWindow: (inlinePreviewWindow: Window) => {
       inlinePreviewWindowRef.current = inlinePreviewWindow
-    },
-    getFramedPreviewWindow: getAndMaybeUpdateFramedPreviewWindow,
-    setFramedPreviewWindow: (framedPreviewWindow: Window) => {
-      framedPreviewWindowRef.current = framedPreviewWindow
-    },
-    getPreviewWindow: getAndMaybeUpdatePreviewWindow,
-    setPreviewWindow: (previewWindow: Window) => {
-      previewWindowRef.current = previewWindow
     },
   }
 

--- a/reality/cloud/xrhome/src/client/editor/token/dev-qr-code-popup.tsx
+++ b/reality/cloud/xrhome/src/client/editor/token/dev-qr-code-popup.tsx
@@ -21,7 +21,6 @@ import {BasicQrCode} from '../../widgets/basic-qr-code'
 import {useSelector} from '../../hooks'
 import {UiThemeProvider} from '../../ui/theme'
 import {hexColorWithAlpha} from '../../../shared/colors'
-import {useAppPreviewWindow} from '../../common/app-preview-window-context'
 import {combine} from '../../common/styles'
 import {useProjectPreviewUrl} from '../app-preview/use-project-preview-url'
 import {Loader} from '../../ui/components/loader'
@@ -206,8 +205,6 @@ const DevQRCodePopup: React.FunctionComponent<IProps> = React.memo(({
   const remoteDeviceUrl = useProjectPreviewUrl(app, 'remote-device')
   const sameDeviceUrl = useProjectPreviewUrl(app, 'same-device')
 
-  const {setPreviewWindow} = useAppPreviewWindow()
-
   useEffect(() => {
     loadPreviewLinkDebugModeSelected()
     ensureSimulatorStateReady(app.appKey)
@@ -240,8 +237,7 @@ const DevQRCodePopup: React.FunctionComponent<IProps> = React.memo(({
         // @ts-ignore
       a8='click;cloud-editor;preview-link'
       onClick={() => {
-        const newTab = window.open(sameDeviceUrl)
-        setPreviewWindow(newTab)
+        window.open(sameDeviceUrl)
       }}
     >
       <span>

--- a/reality/cloud/xrhome/src/client/studio/simulator-view-controls.tsx
+++ b/reality/cloud/xrhome/src/client/studio/simulator-view-controls.tsx
@@ -9,7 +9,6 @@ import {useAppPreviewStyles} from '../editor/app-preview/app-preview-utils'
 import {createThemedStyles} from '../ui/theme'
 import {useProjectPreviewUrl} from '../editor/app-preview/use-project-preview-url'
 import useCurrentApp from '../common/use-current-app'
-import {useAppPreviewWindow} from '../common/app-preview-window-context'
 import {useStudioDebug} from '../editor/app-preview/use-studio-debug-state'
 import {useSimulator} from '../editor/app-preview/use-simulator-state'
 
@@ -44,13 +43,11 @@ const SimulatorViewActions: React.FC<ISimulatorView> = ({simulatorId}) => {
   const {t} = useTranslation('cloud-studio-pages')
   const appPreviewStyles = useAppPreviewStyles()
   const sameDeviceUrl = useProjectPreviewUrl(app, 'same-device')
-  const {setPreviewWindow} = useAppPreviewWindow()
   const {closeDebugSimulatorSession} = useStudioDebug()
   const {updateSimulatorState} = useSimulator()
 
   const handleOpenInBrowser = () => {
-    const newTab = window.open(sameDeviceUrl)
-    setPreviewWindow(newTab)
+    window.open(sameDeviceUrl)
     updateSimulatorState({inlinePreviewVisible: false})
     closeDebugSimulatorSession(simulatorId)
   }


### PR DESCRIPTION
## Context

Setup for https://github.com/8thwall/8thwall/issues/118

In the past, we had the option to open the simulator in a pop out window, and maybe had plumbing to interact with preview links open in a new tab. Now we only have the inline simulator, so we don't need the additional bookkeeping.

## Testing

- `scripts/lint.sh` passes
- `npm run ts:check` passes