### PR TITLE
[xrhome] Switch to context for providing simulator support status

### DIFF
--- a/reality/cloud/xrhome/src/client/editor/app-preview/encode-simulator-config.tsx
+++ b/reality/cloud/xrhome/src/client/editor/app-preview/encode-simulator-config.tsx
@@ -42,7 +42,7 @@ const useSimulatorConfigUrl = (
     currentConfigUrl.searchParams.set('sessionId', sessionId)
   }
 
-  if (BuildIf.STUDIO_DEV8_INTEGRATION_20260205 && liveSyncMode) {
+  if (liveSyncMode) {
     currentConfigUrl.searchParams.set('liveSyncMode', liveSyncMode)
   }
 

--- a/reality/cloud/xrhome/src/client/editor/app-preview/inline-app-preview-pane.tsx
+++ b/reality/cloud/xrhome/src/client/editor/app-preview/inline-app-preview-pane.tsx
@@ -545,7 +545,7 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
               </div>
             )}
           </Measure>
-          {(!collapsed && !hidePreviewBottom && BuildIf.STUDIO_DEV8_INTEGRATION_20260205) && (
+          {(!collapsed && !hidePreviewBottom) && (
             renderPreviewBottom(previewPaneMeasure.contentRect.bounds)
           )}
         </div>

--- a/reality/cloud/xrhome/src/client/studio/debug-simulator-panel.tsx
+++ b/reality/cloud/xrhome/src/client/studio/debug-simulator-panel.tsx
@@ -26,13 +26,12 @@ import {useDebounced} from './use-debounced'
 import {useActiveSpace} from './hooks/active-space'
 import {useProjectPreviewUrl} from '../editor/app-preview/use-project-preview-url'
 import {StandardLink} from '../ui/components/standard-link'
+import {usePlaybackContext} from './playback-context'
 
 const LOADING_SCREEN_DISAPPEAR_DELAY = 200
 
 const MAX_HEIGHT = `100% - ${MARGIN_SIZE} - ${MARGIN_SIZE}`
 const MAX_WIDTH = `max(40%, ${MIN_PREVIEW_WIDTH}px)`
-
-const PENDING_DEBUG_WORK = true
 
 const useStyles = createThemedStyles(theme => ({
   debugSimulatorContainer: {
@@ -87,6 +86,7 @@ const DebugSimulatorPanel: React.FC<IDebugSimulatorPanel> = ({simulatorId}) => {
   const {ensureSimulatorStateReady} = useActions(editorActions)
   const {simulatorState, updateSimulatorState} = useSimulator()
   const {panelHeight, panelWidth} = simulatorState
+  const playbackContext = usePlaybackContext()
 
   const ctx = useSceneContext()
   const allCameras = derivedScene.getAllCameras()
@@ -97,7 +97,9 @@ const DebugSimulatorPanel: React.FC<IDebugSimulatorPanel> = ({simulatorId}) => {
   const activeSpace = useActiveSpace()
   const activeCamera = derivedScene.getActiveCamera(activeSpace?.id)
   const projectUrl = useProjectPreviewUrl(app)
-  const warningBannerMsg = activeCamera?.camera.xr?.xrCameraType === 'world' && projectUrl
+  const warningBannerMsg = activeCamera?.camera.xr?.xrCameraType === 'world' &&
+    !playbackContext.simulatorEnabled &&
+    projectUrl
     ? (
       <span>
         <Trans
@@ -128,15 +130,16 @@ const DebugSimulatorPanel: React.FC<IDebugSimulatorPanel> = ({simulatorId}) => {
     [derivedScene, simulatorState.imageTargetName]
   )
 
+  const debugStatus: string = 'todo'
   // NOTE(christoph): The 'attached-confirmed' state is entered after ECS_ATTACH_CONFIRM is
   // received, which is only sent by a newer version dev8. As a fallback, either in the case of a
   // crash, or an old version of dev8, we hide the loading screen after a delay.
   // If we're attached-confirmed, we don't show the loading screen.
-  const oldDebugStatus = useDebounced(ctx.debugStatus, LOADING_SCREEN_DISAPPEAR_DELAY)
+  const oldDebugStatus = useDebounced(debugStatus, LOADING_SCREEN_DISAPPEAR_DELAY)
   const debugReady = (
-    ctx.debugStatus === 'attach-confirmed' ||
+    debugStatus === 'attach-confirmed' ||
     // Attach has been sent for a while, so hide the loading screen.
-    (ctx.debugStatus === 'attach-sent' && oldDebugStatus === 'attach-sent')
+    (debugStatus === 'attach-sent' && oldDebugStatus === 'attach-sent')
   )
 
   if (!simulatorVisible) {
@@ -191,12 +194,12 @@ const DebugSimulatorPanel: React.FC<IDebugSimulatorPanel> = ({simulatorId}) => {
           simulatorId={simulatorId}
           sessionId={simulatorId.replace(/-/g, '')}
           isDragging={ctx.isDraggingGizmo || resizing}
-          hidePreviewBottom={!anyWorld}
+          hidePreviewBottom={!anyWorld || !playbackContext.simulatorEnabled}
           targetsGalleryUuid={SIMULATOR_PANEL_GALLERY_ID}
           imageTargetQuaternion={imageTargetQuaternion}
           renderActions={() => <SimulatorViewActions simulatorId={simulatorId} />}
-          liveSyncMode='inline'
-          showLoadingOverlay={PENDING_DEBUG_WORK ? false : !debugReady}
+          liveSyncMode={playbackContext.simulatorEnabled ? 'inline' : undefined}
+          showLoadingOverlay={playbackContext.simulatorEnabled ? !debugReady : false}
           warningBannerMsg={warningBannerMsg}
         />
       </ResizablePanel>

--- a/reality/cloud/xrhome/src/client/studio/playback-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/playback-context.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+type PlaybackContext = {
+  simulatorEnabled: boolean
+}
+
+const playbackContext = React.createContext<PlaybackContext | null>(null)
+
+const CURRENT_VALUE: PlaybackContext = {
+  simulatorEnabled: BuildIf.STUDIO_DEV8_INTEGRATION_20260205,
+}
+
+const usePlaybackContext = (): PlaybackContext | null => {
+  const ctx = React.useContext(playbackContext)
+  if (!ctx) {
+    throw new Error('usePlaybackContext must be used within a PlaybackContextProvider')
+  }
+  return ctx
+}
+
+const PlaybackContextProvider: React.FC<{children: React.ReactNode}> = ({children}) => (
+  <playbackContext.Provider value={CURRENT_VALUE}>
+    {children}
+  </playbackContext.Provider>
+)
+
+export {
+  PlaybackContextProvider,
+  usePlaybackContext,
+}
+
+export type {
+  PlaybackContext,
+}

--- a/reality/cloud/xrhome/src/client/studio/readonly-scene-edit-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/readonly-scene-edit-context.tsx
@@ -46,7 +46,6 @@ const ReadonlySceneEditContext: React.FC<IReadonlySceneEditContext> = ({
       undo: noop,
       canRedo: false,
       redo: noop,
-      playsUsingRuntime: true,
     } as const
   }, [
     scene,

--- a/reality/cloud/xrhome/src/client/studio/scene-context.ts
+++ b/reality/cloud/xrhome/src/client/studio/scene-context.ts
@@ -18,8 +18,6 @@ interface RawSceneContext {
   undo: () => void
   canRedo: boolean
   redo: () => void
-  playsUsingRuntime: boolean  // True if play mode should use the runtime with ScenePlay
-  debugStatus?: 'waiting' | 'attach-sent' | 'attach-confirmed'
 }
 
 type SceneContext = DeepReadonly<RawSceneContext>

--- a/reality/cloud/xrhome/src/client/studio/scene-debug-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/scene-debug-context.tsx
@@ -12,6 +12,7 @@ import {useExpanse} from './hooks/expanse'
 import {useSimulator} from '../editor/app-preview/use-simulator-state'
 import {updateObject} from './update-object'
 import {DerivedSceneProvider} from './derived-scene-context'
+import {PlaybackContextProvider} from './playback-context'
 
 type MutateCallback<T> = (old: DeepReadonly<T>) => DeepReadonly<T>
 
@@ -93,13 +94,10 @@ const SceneDebugContext: React.FC<ISceneDebugContext> = ({
           expanseState.update(() => newScene)
         }
       },
-      playsUsingRuntime: false,
-      debugStatus: null,
     } as const
   }, [
     expanseState.scene, isDraggingGizmo,
     undoStack.canRedo, undoStack.canUndo, isRenamingById,
-    // debugStatus: null,
   ])
 
   if (!expanseState.ready) {
@@ -121,7 +119,9 @@ const SceneDebugContext: React.FC<ISceneDebugContext> = ({
   return (
     <SceneContextProvider value={sceneContextValue}>
       <DerivedSceneProvider>
-        {children}
+        <PlaybackContextProvider>
+          {children}
+        </PlaybackContextProvider>
       </DerivedSceneProvider>
     </SceneContextProvider>
   )

--- a/reality/cloud/xrhome/src/client/studio/studio-debug-controls-tray.tsx
+++ b/reality/cloud/xrhome/src/client/studio/studio-debug-controls-tray.tsx
@@ -9,6 +9,7 @@ import {useSimulator, useSimulatorVisible} from '../editor/app-preview/use-simul
 import {useSceneContext} from './scene-context'
 import {ProductTourId} from './product-tour-constants'
 import useCurrentApp from '../common/use-current-app'
+import {usePlaybackContext} from './playback-context'
 
 interface IDebugControlsTray {
   onPlay: () => void
@@ -20,6 +21,7 @@ const StudioDebugControlsTray: React.FC<IDebugControlsTray> = ({onPlay, simulato
   const {state: {isPreviewPaused}} = stateCtx
   const ctx = useSceneContext()
   const {t} = useTranslation('cloud-studio-pages')
+  const playbackContext = usePlaybackContext()
 
   const {closeDebugSimulatorSession} = useStudioDebug()
   const {updateSimulatorState} = useSimulator()
@@ -39,7 +41,7 @@ const StudioDebugControlsTray: React.FC<IDebugControlsTray> = ({onPlay, simulato
 
   return (
     <FloatingTray shrink nonInteractive={ctx.isDraggingGizmo}>
-      {BuildIf.STUDIO_DEV8_INTEGRATION_20260205 && (
+      {playbackContext.simulatorEnabled && (
         <>
           <FloatingIconButton
             text={t('studio_play_button_tray.button.restart')}

--- a/reality/cloud/xrhome/test/nae-utils-test.ts
+++ b/reality/cloud/xrhome/test/nae-utils-test.ts
@@ -15,7 +15,6 @@ const DEFAULT_SCENE_CTX: SceneContext = {
   undo: () => {},
   canRedo: false,
   redo: () => {},
-  playsUsingRuntime: false,
   scene: {objects: {}},
 }
 


### PR DESCRIPTION
## Context

Setup for https://github.com/8thwall/8thwall/issues/118

There will be some runtime checks to see if the simulator is supported, so checking the buildif is not the only factor. 

## Testing

- No change in behavior as the buildif is still disabled.