### PR TITLE
[xrhome] Disable redux logging by default

### DIFF
--- a/reality/cloud/xrhome/src/client/reducer.ts
+++ b/reality/cloud/xrhome/src/client/reducer.ts
@@ -10,6 +10,8 @@ import type {DeepReadonly} from 'ts-essentials'
 
 import {FULL_STACK_REDUCERS} from './full-stack-reducers'
 
+const VERBOSE_LOGGING = false
+
 const history = createMemoryHistory()
 
 // Scroll to the top on every history change
@@ -96,7 +98,7 @@ const getExtendedStore = (preloadedState?: RootState): ExtendedStoreResult => {
     thunk,
   ]
 
-  if (BuildIf.LOCAL_DEV && !BuildIf.UI_TEST && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
+  if (VERBOSE_LOGGING && BuildIf.LOCAL_DEV) {
     middleware.push(createLogger())
   }
 


### PR DESCRIPTION
## Context

We used to use the redux debugger extension in chrome, so this logging was only in the case where that wasn't installed. Now that we're running purely in electron, we don't have that, so other logs are getting lost. 