### PR TITLE
[ecs] Include dev8 bundle in package

### DIFF
--- a/c8/ecs/src/shared/features/inline-simulator.ts
+++ b/c8/ecs/src/shared/features/inline-simulator.ts
@@ -1,0 +1,6 @@
+// @inliner-off
+
+export const INLINE_SIMULATOR_FEATURE = {
+  name: 'inline-simulator',
+  edition: 1,
+} as const

--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -29,6 +29,7 @@
     "index.js",
     "index.d.ts",
     "metadata.json",
+    "dev8",
     "dist"
   ]
 }

--- a/packages/ecs/tools/prepare.sh
+++ b/packages/ecs/tools/prepare.sh
@@ -3,7 +3,7 @@ set -e
 
 ROOT=$(git rev-parse --show-toplevel)
 
-cd $ROOT/packages/ecs
+cd "$ROOT/packages/ecs"
 
 rm -rf tmp
 mkdir -p tmp/dist
@@ -26,7 +26,7 @@ unzip ../../../../bazel-bin/c8/ecs/bundle-without-metadata.zip > /dev/null
 
 mv runtime.d.ts ../index.d.ts
 
-cd $ROOT/packages/dev8
+cd "$ROOT/packages/dev8"
 npm ci
 npm run build
-mv $ROOT/packages/dev8/dist $ROOT/packages/ecs/tmp/dev8
+mv "$ROOT/packages/dev8/dist" "$ROOT/packages/ecs/tmp/dev8"

--- a/packages/ecs/tools/prepare.sh
+++ b/packages/ecs/tools/prepare.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+ROOT=$(git rev-parse --show-toplevel)
+
+cd $ROOT/packages/ecs
+
 rm -rf tmp
 mkdir -p tmp/dist
 
@@ -21,3 +25,8 @@ cd dist
 unzip ../../../../bazel-bin/c8/ecs/bundle-without-metadata.zip > /dev/null
 
 mv runtime.d.ts ../index.d.ts
+
+cd $ROOT/packages/dev8
+npm ci
+npm run build
+mv $ROOT/packages/dev8/dist $ROOT/packages/ecs/tmp/dev8

--- a/reality/cloud/xrhome/src/client/studio/playback-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/playback-context.tsx
@@ -1,14 +1,13 @@
+import {INLINE_SIMULATOR_FEATURE} from '@ecs/shared/features/inline-simulator'
 import React from 'react'
+
+import {useFeatureEnabled} from './runtime-version/use-feature-enabled'
 
 type PlaybackContext = {
   simulatorEnabled: boolean
 }
 
 const playbackContext = React.createContext<PlaybackContext | null>(null)
-
-const CURRENT_VALUE: PlaybackContext = {
-  simulatorEnabled: BuildIf.STUDIO_DEV8_INTEGRATION_20260205,
-}
 
 const usePlaybackContext = (): PlaybackContext | null => {
   const ctx = React.useContext(playbackContext)
@@ -18,11 +17,14 @@ const usePlaybackContext = (): PlaybackContext | null => {
   return ctx
 }
 
-const PlaybackContextProvider: React.FC<{children: React.ReactNode}> = ({children}) => (
-  <playbackContext.Provider value={CURRENT_VALUE}>
-    {children}
-  </playbackContext.Provider>
-)
+const PlaybackContextProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const simulatorEnabled = useFeatureEnabled(INLINE_SIMULATOR_FEATURE)
+  return (
+    <playbackContext.Provider value={{simulatorEnabled}}>
+      {children}
+    </playbackContext.Provider>
+  )
+}
 
 export {
   PlaybackContextProvider,

--- a/reality/cloud/xrhome/src/client/studio/playback-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/playback-context.tsx
@@ -1,13 +1,14 @@
-import {INLINE_SIMULATOR_FEATURE} from '@ecs/shared/features/inline-simulator'
 import React from 'react'
-
-import {useFeatureEnabled} from './runtime-version/use-feature-enabled'
 
 type PlaybackContext = {
   simulatorEnabled: boolean
 }
 
 const playbackContext = React.createContext<PlaybackContext | null>(null)
+
+const CURRENT_VALUE: PlaybackContext = {
+  simulatorEnabled: BuildIf.STUDIO_DEV8_INTEGRATION_20260205,
+}
 
 const usePlaybackContext = (): PlaybackContext | null => {
   const ctx = React.useContext(playbackContext)
@@ -17,14 +18,11 @@ const usePlaybackContext = (): PlaybackContext | null => {
   return ctx
 }
 
-const PlaybackContextProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
-  const simulatorEnabled = useFeatureEnabled(INLINE_SIMULATOR_FEATURE)
-  return (
-    <playbackContext.Provider value={{simulatorEnabled}}>
-      {children}
-    </playbackContext.Provider>
-  )
-}
+const PlaybackContextProvider: React.FC<{children: React.ReactNode}> = ({children}) => (
+  <playbackContext.Provider value={CURRENT_VALUE}>
+    {children}
+  </playbackContext.Provider>
+)
 
 export {
   PlaybackContextProvider,


### PR DESCRIPTION
## Context

Part of #118 

Historically, we pushed dev8 in tandom with the runtime. I think it keeps the mental model simpler. Currently there's not too deep of a dependency but for future updates, tying them directly together seems like the move.

A follow up will be to update the `new-project` config to include this script in the generated output and link to it when in development mode. 

The `inline-simulator` flag will be used by the desktop app to check if the updated ecs version with dev8 included is supported. 

When we add remote debugging, that may be an additional flag. 

## Testing

```
/Users/christoph8/repo/8thwall/packages/ecs/tools/prepare.sh && cd /Users/christoph8/repo/8thwall/packages/ecs/tmp && npm pack
```

```
Contents ===
npm notice 1.1kB   LICENSE
npm notice 1.3kB   README.md
npm notice 2.6MB   dev8/94c8c2b6f8ce911db515.module.wasm
npm notice 7.3kB   dev8/229.dev8.js
npm notice 43.7kB  dev8/337.dev8.js
npm notice 583.7kB dev8/dev8.js
npm notice 1.1kB   dist/LICENSE
npm notice 712.9kB dist/resources/draco/draco_decoder.js
...
npm notice 2.3MB   dist/resources/splat/splat-worker.js
npm notice 4.4MB   dist/runtime.js
npm notice 111.9kB index.d.ts
npm notice 123B    index.js
npm notice 17.2kB  metadata.json
npm notice 675B    package.json
```