### PR TITLE
[ecs] 3.1.0

### DIFF
--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@8thwall/ecs",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "The game engine behind 8th Wall Studio",
   "author": "8th Wall Team",
   "license": "MIT",


### PR DESCRIPTION
## Context

This includes the new dev8 scripts

https://www.npmjs.com/package/@8thwall/ecs/v/3.1.0-alpha1



## Testing

- When using this alpha version, the editor recognizes the supported simulator config and works, as in https://github.com/8thwall/8thwall/pull/126


