### PR TITLE
[xrhome] Factor out useProjectConfigStatus

### DIFF
--- a/reality/cloud/xrhome/src/client/hooks/use-project-config.ts
+++ b/reality/cloud/xrhome/src/client/hooks/use-project-config.ts
@@ -1,0 +1,27 @@
+import {queryOptions, useQuery, useSuspenseQuery} from '@tanstack/react-query'
+
+import {MILLISECONDS_PER_HOUR} from '../../shared/time-utils'
+import {useEnclosedAppKey} from '../apps/enclosed-app-context'
+import {checkConfigStatus} from '../studio/local-sync-api'
+
+const getProjectConfigStatusQuery = (appKey: string) => queryOptions({
+  queryKey: ['project-config', appKey],
+  queryFn: () => checkConfigStatus(appKey),
+  staleTime: MILLISECONDS_PER_HOUR,
+})
+
+const useProjectConfigStatus = () => {
+  const appKey = useEnclosedAppKey()
+  return useSuspenseQuery(getProjectConfigStatusQuery(appKey)).data
+}
+
+const useProjectConfigStatusOrLoading = () => {
+  const appKey = useEnclosedAppKey()
+  return useQuery(getProjectConfigStatusQuery(appKey))
+}
+
+export {
+  useProjectConfigStatus,
+  useProjectConfigStatusOrLoading,
+  getProjectConfigStatusQuery,
+}

--- a/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
@@ -21,6 +21,7 @@ import type {IGit} from '../git/g8-dto'
 import {useStudioStateContext} from './studio-state-context'
 import {useEnclosedAppKey} from '../apps/enclosed-app-context'
 import {getRuntimeMetadataQuery} from './runtime-version/use-runtime-metadata'
+import {getProjectConfigStatusQuery} from '../hooks/use-project-config'
 
 type FileSyncStatus =
 | 'checking'  // Checking what the local state is
@@ -343,6 +344,7 @@ const LocalSyncContextProvider: React.FC<{children: React.ReactNode}> = ({childr
     }
 
     queryClient.invalidateQueries(getRuntimeMetadataQuery(appKey))
+    queryClient.invalidateQueries(getProjectConfigStatusQuery(appKey))
   }
 
   useAbandonableEffect(async (abandon) => {

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {createUseStyles} from 'react-jss'
 import {useTranslation} from 'react-i18next'
-import {queryOptions, useQuery, useQueryClient} from '@tanstack/react-query'
+import {useQuery} from '@tanstack/react-query'
 
 import {useSceneContext} from './scene-context'
 import {useCurrentGit} from '../git/hooks/use-current-git'
@@ -16,12 +16,12 @@ import {StandardModalContent} from '../ui/components/standard-modal-content'
 import {StandardModalActions} from '../ui/components/standard-modal-actions'
 import {TertiaryButton} from '../ui/components/tertiary-button'
 import {StandardModalHeader} from '../ui/components/standard-modal-header'
-import {
-  applyProjectConfigFix, checkConfigStatus,
-} from './local-sync-api'
+import {applyProjectConfigFix} from './local-sync-api'
 import useCurrentApp from '../common/use-current-app'
 import {useLocalSyncContext} from './local-sync-context'
-import {MILLISECONDS_PER_HOUR} from '../../shared/time-utils'
+import {
+  getProjectConfigStatusQuery, useProjectConfigStatusOrLoading,
+} from '../hooks/use-project-config'
 
 const useStyles = createUseStyles({
   recommendationBox: {
@@ -117,18 +117,11 @@ const AssetBundleRecommendation = () => {
   )
 }
 
-const getProjectConfigStatusQuery = (appKey: string) => queryOptions({
-  queryKey: ['project-config', appKey],
-  queryFn: () => checkConfigStatus(appKey),
-  staleTime: MILLISECONDS_PER_HOUR,
-})
-
 const WebpackInjectFixRecommendation = () => {
   const {t} = useTranslation(['cloud-studio-pages', 'common'])
   const {appKey} = useCurrentApp()
   const localSyncContext = useLocalSyncContext()
-  const needsInjectFix = useQuery(getProjectConfigStatusQuery(appKey)).data?.needsInjectFix
-  const queryClient = useQueryClient()
+  const needsInjectFix = useProjectConfigStatusOrLoading().data?.needsInjectFix
   const [dismissed, setDismissed] = React.useState(false)
   const visible = needsInjectFix && !dismissed
 
@@ -144,7 +137,6 @@ const WebpackInjectFixRecommendation = () => {
           <BoldButton onClick={async () => {
             await applyProjectConfigFix(appKey, 'inject')
             await localSyncContext.restartServer()
-            queryClient.invalidateQueries(getProjectConfigStatusQuery(appKey))
           }}
           >
             {t('recommendation_box.fix')}
@@ -163,7 +155,6 @@ const CopyPluginFixRecommendation = () => {
   const {appKey} = useCurrentApp()
   const localSyncContext = useLocalSyncContext()
   const needsCopyPluginFix = useQuery(getProjectConfigStatusQuery(appKey)).data?.needsCopyPluginFix
-  const queryClient = useQueryClient()
   const [dismissed, setDismissed] = React.useState(false)
   const visible = needsCopyPluginFix && !dismissed
 
@@ -179,7 +170,6 @@ const CopyPluginFixRecommendation = () => {
           <BoldButton onClick={async () => {
             await applyProjectConfigFix(appKey, 'copy-plugin')
             await localSyncContext.restartServer()
-            queryClient.invalidateQueries(getProjectConfigStatusQuery(appKey))
           }}
           >
             {t('recommendation_box.fix')}


### PR DESCRIPTION
## Context

Moving this to support accessing the config status from other files. 

## Testing

- `npm run ts:check` passes