### PR TITLE
[xrhome] Resume from previous path in local

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/desktop-app.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/desktop-app.tsx
@@ -26,14 +26,25 @@ interface IApp {
   history: History
 }
 
+const getInitialPath = () => {
+  if (BuildIf.LOCAL) {
+    return localStorage.getItem('saved-path') || HOME_PATH
+  }
+
+  return HOME_PATH
+}
+
 const HistoryResumer = ({children}: {children: React.ReactElement}) => {
   const {pathname: currentPath} = useLocation()
+  React.useEffect(() => {
+    localStorage.setItem('saved-path', currentPath)
+  }, [currentPath])
 
   if (currentPath !== ROOT_PATH) {
     return children
   }
 
-  return <Redirect to={HOME_PATH} />
+  return <Redirect to={getInitialPath()} />
 }
 
 const InnerApp: React.FC = () => {

--- a/reality/cloud/xrhome/src/client/desktop/desktop-app.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/desktop-app.tsx
@@ -37,7 +37,9 @@ const getInitialPath = () => {
 const HistoryResumer = ({children}: {children: React.ReactElement}) => {
   const {pathname: currentPath} = useLocation()
   React.useEffect(() => {
-    localStorage.setItem('saved-path', currentPath)
+    if (BuildIf.LOCAL) {
+      localStorage.setItem('saved-path', currentPath)
+    }
   }, [currentPath])
 
   if (currentPath !== ROOT_PATH) {


### PR DESCRIPTION
## Context

This was decided against for the production release, always wanting to go to the homepage on launch, however, for local development, it would be nice if refreshing/relaunching would stay on the same view. 

## Testing

- Refreshing/relaunching keeps the selected app active