### PR TITLE
[xrhome] Switch to local asset for cover image

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
@@ -7,8 +7,6 @@ import {Trans, useTranslation} from 'react-i18next'
 
 import type {ProjectClientSide} from '../../shared/desktop/local-sync-types'
 import {getLocalStudioPath} from './desktop-paths'
-import {deriveAppCoverImageUrl} from '../../shared/app-utils'
-import {COVER_IMAGE_PREVIEW_SIZES} from '../../shared/app-constants'
 import {SpaceBetween} from '../ui/layout/space-between'
 import {combine} from '../common/styles'
 import {ProjectListItemOptions} from './project-list-item-options'
@@ -21,6 +19,7 @@ import {basename} from '../editor/editor-common'
 import {createThemedStyles} from '../ui/theme'
 import {StandardLink} from '../ui/components/standard-link'
 import {Icon} from '../ui/components/icon'
+import coverImg from '../static/cover-image.png'
 
 const useStyles = createThemedStyles(theme => ({
   projectListItem: {
@@ -115,6 +114,15 @@ const ProjectListItem: React.FC<IProjectListItem> = ({project}) => {
   const [isMigrateModalOpen, setIsMigrateModalOpen] = React.useState(false)
   const history = useHistory()
 
+  const coverStyle = React.useMemo(() => {
+    let i = 0
+    Array.from(project.location).forEach((e) => {
+      i += e.charCodeAt(0)
+    })
+    const degrees = 360 * (Math.floor(i % 6) / 6)
+    return {filter: `hue-rotate(${degrees}deg)`}
+  }, [project.location])
+
   const onClose = () => {
     setIsMovingAppModalOpen(false)
     setIsMigrateModalOpen(false)
@@ -141,7 +149,8 @@ const ProjectListItem: React.FC<IProjectListItem> = ({project}) => {
             <img
               className={classes.coverImage}
               draggable={false}
-              src={deriveAppCoverImageUrl(null, COVER_IMAGE_PREVIEW_SIZES[600])}
+              src={coverImg}
+              style={coverStyle}
               alt=''
             />
             <div className={classes.textContainer}>

--- a/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
@@ -105,6 +105,14 @@ interface IProjectListItem {
   project: ProjectClientSide & {appKey: string}
 }
 
+const HUE_ROTATE_VALUES = [
+  0,
+  75,
+  110,
+  160,
+  260,
+]
+
 const ProjectListItem: React.FC<IProjectListItem> = ({project}) => {
   const classes = useStyles()
   const {t} = useTranslation(['studio-desktop-pages'])
@@ -115,11 +123,11 @@ const ProjectListItem: React.FC<IProjectListItem> = ({project}) => {
   const history = useHistory()
 
   const coverStyle = React.useMemo(() => {
-    let i = 0
-    Array.from(project.location).forEach((e) => {
-      i += e.charCodeAt(0)
-    })
-    const degrees = 360 * (Math.floor(i % 6) / 6)
+    let roughHash = 0
+    for (let i = 0; i < project.location.length; i++) {
+      roughHash += project.location.charCodeAt(i)
+    }
+    const degrees = HUE_ROTATE_VALUES[Math.floor(roughHash % HUE_ROTATE_VALUES.length)]
     return {filter: `hue-rotate(${degrees}deg)`}
   }, [project.location])
 

--- a/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
@@ -107,10 +107,10 @@ interface IProjectListItem {
 
 const HUE_ROTATE_VALUES = [
   0,
-  75,
-  110,
-  160,
-  260,
+  85,
+  120,
+  200,
+  280,
 ]
 
 const ProjectListItem: React.FC<IProjectListItem> = ({project}) => {

--- a/reality/cloud/xrhome/src/client/static/cover-image.png
+++ b/reality/cloud/xrhome/src/client/static/cover-image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c795cd26b0cd6f15f10dddb1cd7d922835fe431dee4173b37c1ca2520df9507
+size 257185

--- a/reality/cloud/xrhome/src/shared/app-constants.ts
+++ b/reality/cloud/xrhome/src/shared/app-constants.ts
@@ -1,12 +1,5 @@
 const MEGA = 2 ** 20
 
-const COVER_IMAGE_PREVIEW_SIZES = {
-  1200: [1200, 630],
-  600: [600, 315],
-  400: [400, 210],
-}
-
 export {
   MEGA,
-  COVER_IMAGE_PREVIEW_SIZES,
 }

--- a/reality/cloud/xrhome/src/shared/app-utils.ts
+++ b/reality/cloud/xrhome/src/shared/app-utils.ts
@@ -1,16 +1,6 @@
-import {
-  COVER_IMAGE_PREVIEW_SIZES,
-} from './app-constants'
 import type {IApp} from '../client/common/types/models'
 
 type PickApp<T extends keyof (IApp)> = Pick<IApp, T>
-
-// TODO(christoph): Remove cdn dependency
-const deriveAppCoverImageUrl = (_app: {}, size = COVER_IMAGE_PREVIEW_SIZES[1200]) => {
-  const width = size[0]
-  const height = size[1]
-  return `https://cdn.8thwall.com/apps/cover/default0-preview-${width}x${height}`
-}
 
 const getDisplayNameForApp = (app: PickApp<'appTitle' | 'appName'>) => app.appTitle || app.appName
 
@@ -21,7 +11,6 @@ const isCloudStudioApp: AppCheck = () => true
 const isActiveCommercialApp: AppCheck = () => false
 
 export {
-  deriveAppCoverImageUrl,
   getDisplayNameForApp,
   isActiveCommercialApp,
   isCloudStudioApp,


### PR DESCRIPTION

## Context

Removes a dependency on cdn.8thwall.com and improves (slightly) the ability to distinguish between projects. 

Would be good to explore pulling actual cover images from the projects also. 


## Testing

| Before | After |
| ------ | ------ |
|   <img width="1486" height="524" alt="Screenshot 2026-05-06 at 11 58 49 PM" src="https://github.com/user-attachments/assets/dbb80687-d851-4dd4-88fa-2e9fa8752208" />     |    <img width="1602" height="641" alt="Screenshot 2026-05-06 at 11 58 29 PM" src="https://github.com/user-attachments/assets/fbcc0f94-44bf-45f1-ab7d-22833a6483f9" />    |