### PR TITLE
[xrhome] Switch to open source managed cdn for simulator sequences

### DIFF
--- a/reality/cloud/xrhome/src/client/editor/app-preview/app-preview-utils.tsx
+++ b/reality/cloud/xrhome/src/client/editor/app-preview/app-preview-utils.tsx
@@ -5,10 +5,6 @@ import {Icon, IconStroke} from '../../ui/components/icon'
 import {createThemedStyles} from '../../ui/theme'
 import type {AspectOptionId} from '../editor-reducer'
 
-const APP_PREVIEW_METADATA_SRC = 'https://cdn.8thwall.com/web/app-preview/sequence_metadata.json'
-// NOTE(Dale): Dev version used while testing
-// 'https://cdn-dev.8thwall.com/pr/756/5uofxfxg/web/app-preview/sequence_metadata.json'
-
 const MIN_PREVIEW_WIDTH = 250
 const MIN_PREVIEW_HEIGHT = 500
 const DEFAULT_PREVIEW_WIDTH = '25rem'
@@ -348,7 +344,6 @@ const getCurrentRecording = (
 
 export {
   ACTION_BUTTON_TEXT_MIN_WIDTH,
-  APP_PREVIEW_METADATA_SRC,
   DEFAULT_PREVIEW_WIDTH,
   MIN_PREVIEW_HEIGHT,
   MIN_PREVIEW_WIDTH,

--- a/reality/cloud/xrhome/src/client/editor/app-preview/inline-app-preview-pane.tsx
+++ b/reality/cloud/xrhome/src/client/editor/app-preview/inline-app-preview-pane.tsx
@@ -7,21 +7,16 @@ import type {DeepReadonly} from 'ts-essentials'
 import type {IApp} from '../../common/types/models'
 import {combine} from '../../common/styles'
 import {IconButton} from '../../ui/components/icon-button'
-import editorActions from '../editor-actions'
-import useActions from '../../common/use-actions'
 import {createThemedStyles} from '../../ui/theme'
 import {AppPreviewBottomBar} from './app-preview-bottom-bar'
 import {
-  APP_PREVIEW_METADATA_SRC,
   MIN_PREVIEW_WIDTH,
   MIN_PREVIEW_HEIGHT,
   getCurrentRecording,
   SectionData,
-  SequenceMetadata,
   SimulatorConfig,
   useAppPreviewStyles,
 } from './app-preview-utils'
-import {useAbandonableEffect} from '../../hooks/abandonable-effect'
 import {useChangeEffect} from '../../hooks/use-change-effect'
 import {InitializingScreen} from './initializing-screen'
 import {Loader} from '../../ui/components/loader'
@@ -42,6 +37,7 @@ import {Keys} from '../../studio/common/keys'
 import {AppPreviewMockLocation} from './app-preview-mock-location'
 import {AppPreviewAspectRatio} from './app-preview-aspect-ratio'
 import {StaticBanner} from '../../ui/components/banner'
+import {SEQUENCE_METADATA} from './sequence-metadata'
 
 const useStyles = createThemedStyles(theme => ({
   appPreviewPane: {
@@ -150,10 +146,7 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
   const appPreviewStyles = useAppPreviewStyles()
   const {t} = useTranslation(['cloud-editor-pages'])
 
-  const {fetchSequenceMetadata} = useActions(editorActions)
-
   const [loadingSequence, setLoadingSequence] = React.useState<boolean>(false)
-  const [sequenceMetadata, setSequenceMetadata] = React.useState<SequenceMetadata>(null)
 
   const {simulatorState, updateSimulatorState} = useSimulator()
   const {setInlinePreviewWindow} = useAppPreviewWindow()
@@ -168,15 +161,10 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
   const wantsLandscapeRecording = responsive ? responsiveWidth > responsiveHeight : isLandscape
 
   const sequenceSelection = resolveSequenceSelection(
-    sequenceMetadata,
+    SEQUENCE_METADATA,
     simulatorState,
     null
   )
-
-  // TODO(Dale): Clean up double fetch with app-preview-bottom-bar.tsx
-  useAbandonableEffect(async (abandonable) => {
-    setSequenceMetadata(await abandonable(fetchSequenceMetadata(APP_PREVIEW_METADATA_SRC)))
-  }, [])
 
   useWindowMessageHandler((event) => {
     if (event.data.action === 'SIMULATOR_SEQUENCE_LOADING') {
@@ -208,7 +196,7 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
       cameraUrl: currentRecording.cameraUrl,
       sequenceUrl: currentRecording.sequenceUrl,
       isPaused,
-      userAgent: sequenceMetadata?.defaultUserAgent,
+      userAgent: SEQUENCE_METADATA.defaultUserAgent,
       start,
       end,
       imageTargetName,
@@ -221,7 +209,7 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
       mockCoordinateValue,
     }
   }, [
-    sequenceMetadata?.defaultUserAgent, isPaused, isLiveView, start, end,
+    SEQUENCE_METADATA.defaultUserAgent, isPaused, isLiveView, start, end,
     isLandscape, sequenceSelection?.variation, simulatorId, wantsLandscapeRecording,
     hidePreviewBottom, imageTargetName,
     imageTargetQuaternion, mockLat, mockLng, mockCoordinateValue,
@@ -399,7 +387,7 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
     <AppPreviewBottomBar
       selectedSequence={sequenceSelection?.sequence}
       selectedVariation={sequenceSelection?.variationName}
-      sequences={sequenceMetadata?.sequences}
+      sequences={SEQUENCE_METADATA.sequences}
       simulatorId={simulatorId}
       broadcastSimulatorMessage={broadcastSimulatorMessage}
       maxDropdownHeight={responsiveHeight * 0.8}

--- a/reality/cloud/xrhome/src/client/editor/app-preview/sequence-metadata.ts
+++ b/reality/cloud/xrhome/src/client/editor/app-preview/sequence-metadata.ts
@@ -1,0 +1,373 @@
+/* eslint-disable local-rules/hardcoded-copy */
+/* eslint-disable max-len */
+import type {SequenceMetadata} from './app-preview-utils'
+
+const RESOURCE_BASE = 'https://simulator.8thwallcdn.org/sequences/resources'
+
+const SEQUENCE_METADATA: SequenceMetadata = {
+  'defaultUserAgent': 'Mozilla/5.0 (Linux; Android 10; Pixel 3a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36',
+  'sequences': [
+    {
+      'name': 'Sidewalk',
+      'tag': 'World',
+      'section': 'WORLD',
+      'variations': {
+        'Standing': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700173781768-iphone11-4-1.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700173781768-iphone11-4-1`,
+        },
+        'Walking': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700173940464-iphone11-4-1.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700173940464-iphone11-4-1`,
+        },
+        'Leaves': {
+          'cameraUrl': `${RESOURCE_BASE}/lpucidko/video.1700174117952-iphone11-4-3.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpucidko/log.1700174117952-iphone11-4-3`,
+        },
+        'Orbit': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700175142093-iphone11-4-1.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700175142093-iphone11-4-1`,
+        },
+        'Sky Tilt': {
+          'cameraUrl': `${RESOURCE_BASE}/lsaxwan3/video.1700174645216-iphone11-4-1.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lsaxwan3/log.1700174645216-iphone11-4-1`,
+        },
+        'Sky Pan': {
+          'cameraUrl': `${RESOURCE_BASE}/lsaxwan3/video.1700174470184-iphone11-4-1.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lsaxwan3/log.1700174470184-iphone11-4-1`,
+        },
+      },
+    },
+    {
+      'name': 'City Park',
+      'tag': 'World',
+      'section': 'WORLD',
+      'variations': {
+        'Standing': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700175337993-iphone11-4-4.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700175337993-iphone11-4-4`,
+        },
+        'Moving': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700175374122-iphone11-4-4.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700175374122-iphone11-4-4`,
+        },
+        'Pan': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700175405177-iphone11-4-4.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700175405177-iphone11-4-4`,
+        },
+        'Absolute Scale': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700175449228-iphone11-4-4.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700175449228-iphone11-4-4`,
+        },
+      },
+    },
+    {
+      'name': 'Lounge',
+      'tag': 'World',
+      'section': 'WORLD',
+      'variations': {
+        'Standing': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700608719310-iphone11-4-4.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700608719310-iphone11-4-4`,
+        },
+        'Moving': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700608746556-iphone11-4-4.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700608746556-iphone11-4-4`,
+        },
+      },
+    },
+    {
+      'name': 'Bay Bridge',
+      'tag': 'World',
+      'section': 'WORLD',
+      'variations': {
+        'Standing': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1701296736589-iphone11-4-6.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1701296736589-iphone11-4-6`,
+        },
+        'Moving': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1701296765169-iphone11-4-6.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1701296765169-iphone11-4-6`,
+        },
+        'Sky': {
+          'cameraUrl': `${RESOURCE_BASE}/lsaxwan3/video.1701296831035-iphone11-4-6.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lsaxwan3/log.1701296831035-iphone11-4-6`,
+        },
+        'Sky Pan': {
+          'cameraUrl': `${RESOURCE_BASE}/lsaxwan3/video.1701296795639-iphone11-4-6.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lsaxwan3/log.1701296795639-iphone11-4-6`,
+        },
+      },
+    },
+    {
+      'name': 'Ferry Building',
+      'tag': 'World',
+      'section': 'WORLD',
+      'variations': {
+        'Standing': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1701297685125-iphone11-4-7.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1701297685125-iphone11-4-7`,
+        },
+        'Moving': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1701297712901-iphone11-4-7.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1701297712901-iphone11-4-7`,
+        },
+        'Pan': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1701297810466-iphone11-4-7.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1701297810466-iphone11-4-7`,
+        },
+        'Orbit': {
+          'cameraUrl': `${RESOURCE_BASE}/lpucidko/video.1701297844618-iphone11-4-7.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpucidko/log.1701297844618-iphone11-4-7`,
+        },
+        'Zoom': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1701297897936-iphone11-4-7.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1701297897936-iphone11-4-7`,
+        },
+        'Sky Tilt': {
+          'cameraUrl': `${RESOURCE_BASE}/lsaxwan3/video.1701297456016-iphone11-4-4.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lsaxwan3/log.1701297456016-iphone11-4-4`,
+        },
+      },
+    },
+    {
+      'name': 'Jellyfish Flyer',
+      'tag': 'Flat',
+      'section': 'IMAGE_TARGETS',
+      'variations': {
+        'Flyer': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700608939169-iphone11-4-6.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700608939169-iphone11-4-6`,
+        },
+      },
+    },
+    {
+      'name': 'Wine Bottle',
+      'tag': 'Cylindrical',
+      'section': 'IMAGE_TARGETS',
+      'variations': {
+        'Label': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700609244431-iphone11-4-8.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700609244431-iphone11-4-8`,
+        },
+      },
+    },
+    {
+      'name': 'Coffee Cup',
+      'tag': 'Conical',
+      'section': 'IMAGE_TARGETS',
+      'variations': {
+        'Sleeve': {
+          'cameraUrl': `${RESOURCE_BASE}/lpt23s4c/video.1700609373447-iphone11-4-11.mp4`,
+          'sequenceUrl': `${RESOURCE_BASE}/lpt23s4c/log.1700609373447-iphone11-4-11`,
+        },
+      },
+    },
+    {
+      'name': 'Expressions',
+      'tag': 'Face',
+      'section': 'PEOPLE',
+      'variations': {
+        'Ava': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Expressions-Ava-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Expressions-Ava-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Ivy': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Expressions-Ivy-28.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Expressions-Ivy-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Jay': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Expressions-Jay-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Expressions-Jay-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Zoe': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Expressions-Zoe-28.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Expressions-Zoe-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+      },
+    },
+    {
+      'name': 'Eye Motion',
+      'tag': 'Face',
+      'section': 'PEOPLE',
+      'variations': {
+        'Ivy': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/EyeMotion-Ivy-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/EyeMotion-Ivy-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Ava': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/EyeMotion-Ava-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/EyeMotion-Ava-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+      },
+    },
+    {
+      'name': 'Mouth Motion',
+      'tag': 'Face',
+      'section': 'PEOPLE',
+      'variations': {
+        'Ivy': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/MouthMotion-Ivy-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/MouthMotion-Ivy-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Ava': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/MouthMotion-Ava-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/MouthMotion-Ava-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+      },
+    },
+    {
+      'name': 'Head Motion',
+      'tag': 'Face',
+      'section': 'PEOPLE',
+      'variations': {
+        'Ava': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/HeadMotion-Ava-28.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/HeadMotion-Ava-28.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Ivy': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/HeadMotion-Ivy-28.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/HeadMotion-Ivy-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+      },
+    },
+    {
+      'name': 'Group',
+      'tag': 'Face',
+      'section': 'PEOPLE',
+      'variations': {
+        'Pair': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Expressions-Pair-28.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Expressions-Pair-28.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Trio': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Expressions-Trio-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Expressions-Trio-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+      },
+    },
+    {
+      'name': 'Gestures',
+      'tag': 'Hand',
+      'section': 'PEOPLE',
+      'variations': {
+        'Left Hand': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Left-Hand-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Left-Hand-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Right Hand': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Right-Hand-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Right-Hand-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Ava': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Front-Ava-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Front-Ava-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+        'Jay': [
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/3_4/Front-Jay-26.mp4`,
+            'orientation': 'portrait',
+          },
+          {
+            'cameraUrl': `${RESOURCE_BASE}/lpt1hn32/4_3/Front-Jay-26.mp4`,
+            'orientation': 'landscape',
+          },
+        ],
+      },
+    },
+  ],
+}
+
+export {
+  SEQUENCE_METADATA,
+}

--- a/reality/cloud/xrhome/src/client/editor/editor-actions.ts
+++ b/reality/cloud/xrhome/src/client/editor/editor-actions.ts
@@ -4,7 +4,6 @@ import localForage from 'localforage'
 import {dispatchify} from '../common'
 import type {AsyncThunk, DispatchifiedActions} from '../common/types/actions'
 import type {SimulatorState, StudioDebugSession} from './editor-reducer'
-import unauthenticatedFetch from '../common/unauthenticated-fetch'
 
 const getStudioFileBrowserHeightPercentKey = (repoId: string) => (
   `studio-file-browser-height-percent-${repoId}`
@@ -84,15 +83,6 @@ const ensureSimulatorStateReady = (
   }
 }
 
-const fetchSequenceMetadata = (url: string) => async (dispatch) => {
-  try {
-    return await dispatch(unauthenticatedFetch(url))
-  } catch (err) {
-    dispatch({type: 'ERROR', msg: `Failed to fetch metadata for simulator sequences at ${url}`})
-    throw err
-  }
-}
-
 const selectDebugSession = (
   appKey: string, session: StudioDebugSession, inlinePreviewSession: boolean
 ): AsyncThunk<void> => async (dispatch, getState) => {
@@ -127,7 +117,6 @@ const rawActions = {
   deleteEditorLogStream,
   disconnectDebugSession,
   ensureSimulatorStateReady,
-  fetchSequenceMetadata,
   loadConsoleInputHistory,
   loadPreviewLinkDebugModeSelected,
   removeSimulatorSession,


### PR DESCRIPTION
## Context

Part of #118 

Previously we were pulling sequences from cdn.8thwall.com but the open source project doesn't have control over that domain. 

Cloudflare account: https://dash.cloudflare.com/bb3b51c19f796bfff221d9fde83cd024/members

Invited Kaci and Evan

## Testing
<img width="1343" height="708" alt="Screenshot 2026-05-07 at 2 54 38 PM" src="https://github.com/user-attachments/assets/91ea3db4-d8b6-49fd-a415-9721838a0912" />

