### PR TITLE
[gulp] Copy ECS Resources to dist-desktop

### DIFF
--- a/reality/cloud/xrhome/gulpfile.ts
+++ b/reality/cloud/xrhome/gulpfile.ts
@@ -14,7 +14,7 @@ import desktopConfig from './webpack.desktop'
 import {BuildIfEnv, getBuildIfReplacements} from './src/shared/buildif'
 import type {Build8Replacements} from './src/shared/build8'
 import {CODE8, runChildProcess} from './tools/gulp/process'
-import {wrapBazel, bazelBuild, bazelOutputFiles} from './tools/gulp/bazel'
+import {wrapBazel, BAZEL_SILENT_OPTIONS, BAZEL_STDOUT_ONLY_OPTIONS} from './tools/gulp/bazel'
 import {createLiveBuildIfReplacements} from './tools/gulp/buildif-watch'
 
 const DESKTOP_OUTPUT_DIR = 'desktop-dist'
@@ -269,23 +269,33 @@ const buildDesktopWorker = () => runBundle(desktopWorkerBundle)
 const hotReloadDesktop = () => hotReloadBundle(desktopBundle, 3602)
 const watchDesktop = () => watchBundle(desktopBundle)
 
-// Mirror every output declared by //c8/ecs/resources into desktop-dist/ecs-resources/
 const copyEcsResources = async () => {
-  const flags = ['--config=wasmreleasesimd']
-  await bazelBuild(['//c8/ecs/resources'], flags)
-  const files = await bazelOutputFiles(['//c8/ecs/resources'], flags)
+  const config = `--config=${isProduction ? 'wasmreleasesimd' : 'wasm'}`
+  const target = '//c8/ecs/resources'
 
-  const ECS = '/c8/ecs/resources/'
-  await new Promise<void>((resolve, reject) => {
-    src(files, {cwd: CODE8})
-      .pipe(dest((file) => {
-        const idx = file.path.indexOf(ECS)
-        if (idx < 0) throw new Error(`Path outside ${ECS}: ${file.path}`)
-        const sub = file.path.slice(idx + ECS.length)
-        return path.join(DESKTOP_OUTPUT_DIR, 'ecs-resources', path.dirname(sub))
-      }))
-      .on('end', resolve)
-      .on('error', reject)
+  await wrapBazel(async () => {
+    await runChildProcess(
+      `bazel build ${BAZEL_SILENT_OPTIONS} ${config} -- ${target}`,
+      {cwd: CODE8}
+    )
+    const out = await runChildProcess(
+      `bazel cquery --output=files ${BAZEL_STDOUT_ONLY_OPTIONS} ${config} -- ${target}`,
+      {cwd: CODE8, stdio: ['ignore', 'pipe', 'inherit']}
+    )
+    const files = out.split('\n').filter(Boolean)
+
+    const ecsResourceBase = path.join('c8', 'ecs', 'resources')
+    await new Promise<void>((resolve, reject) => {
+      src(files, {cwd: CODE8})
+        .pipe(dest((file) => {
+          const idx = file.path.indexOf(ecsResourceBase)
+          if (idx < 0) throw new Error(`Path outside ${ecsResourceBase}: ${file.path}`)
+          const sub = file.path.slice(idx + ecsResourceBase.length)
+          return path.join(DESKTOP_OUTPUT_DIR, 'ecs-resources', path.dirname(sub))
+        }))
+        .on('end', resolve)
+        .on('error', reject)
+    })
   })
 }
 

--- a/reality/cloud/xrhome/gulpfile.ts
+++ b/reality/cloud/xrhome/gulpfile.ts
@@ -14,7 +14,7 @@ import desktopConfig from './webpack.desktop'
 import {BuildIfEnv, getBuildIfReplacements} from './src/shared/buildif'
 import type {Build8Replacements} from './src/shared/build8'
 import {CODE8, runChildProcess} from './tools/gulp/process'
-import {wrapBazel} from './tools/gulp/bazel'
+import {wrapBazel, bazelBuild, bazelOutputFiles} from './tools/gulp/bazel'
 import {createLiveBuildIfReplacements} from './tools/gulp/buildif-watch'
 
 const DESKTOP_OUTPUT_DIR = 'desktop-dist'
@@ -269,11 +269,25 @@ const buildDesktopWorker = () => runBundle(desktopWorkerBundle)
 const hotReloadDesktop = () => hotReloadBundle(desktopBundle, 3602)
 const watchDesktop = () => watchBundle(desktopBundle)
 
-const copyEcsResources = () => (
-  // TODO(christoph): Add additional resources as needed.
-  src('../../../c8/ecs/resources/fonts/*/**')
-    .pipe(dest(`${DESKTOP_OUTPUT_DIR}/ecs-resources/fonts`))
-)
+// Mirror every output declared by //c8/ecs/resources into desktop-dist/ecs-resources/
+const copyEcsResources = async () => {
+  const flags = ['--config=wasmreleasesimd']
+  await bazelBuild(['//c8/ecs/resources'], flags)
+  const files = await bazelOutputFiles(['//c8/ecs/resources'], flags)
+
+  const ECS = '/c8/ecs/resources/'
+  await new Promise<void>((resolve, reject) => {
+    src(files, {cwd: CODE8})
+      .pipe(dest((file) => {
+        const idx = file.path.indexOf(ECS)
+        if (idx < 0) throw new Error(`Path outside ${ECS}: ${file.path}`)
+        const sub = file.path.slice(idx + ECS.length)
+        return path.join(DESKTOP_OUTPUT_DIR, 'ecs-resources', path.dirname(sub))
+      }))
+      .on('end', resolve)
+      .on('error', reject)
+  })
+}
 
 const desktop = series(
   clean,

--- a/reality/cloud/xrhome/src/client/studio/hooks/gltf.tsx
+++ b/reality/cloud/xrhome/src/client/studio/hooks/gltf.tsx
@@ -6,11 +6,13 @@ import {suspend} from 'suspend-react'
 
 import {useGLTF} from '@react-three/drei'
 
-import {DRACO_DECODER_PATH} from '../../../shared/studio/cdn-assets'
+import {getResourceBase} from '@ecs/shared/resources'
 
 import type {ModelInfo} from '../../editor/asset-preview-types'
 import {clone as skeletonClone} from '../skeleton-utils'
 import {cloneMaterialAndGeometry, getObject3DInfo} from '../asset-previews/asset-utils'
+
+const DRACO_DECODER_PATH = `${getResourceBase()}draco/`
 
 const resolveInput = (input: string | null | undefined) => {
   if (!input) {

--- a/reality/cloud/xrhome/src/client/studio/use-splat-model.ts
+++ b/reality/cloud/xrhome/src/client/studio/use-splat-model.ts
@@ -1,9 +1,9 @@
 import React from 'react'
 
 import {loadScript} from '@ecs/shared/load-script'
+import {getResourceBase} from '@ecs/shared/resources'
 import type {IModel} from '@ecs/shared/splat-model'
 
-import {SPLAT_MODEL_URL, SPLAT_WORKER_URL} from '../../shared/studio/cdn-assets'
 import {useAbandonableEffect} from '../hooks/abandonable-effect'
 
 let loadScriptPromise: Promise<void> | null = null
@@ -19,10 +19,10 @@ const useSplatModelLoaded = () => {
     }
 
     if (!loadScriptPromise) {
-      loadScriptPromise = loadScript(SPLAT_MODEL_URL)
+      loadScriptPromise = loadScript(`${getResourceBase()}splat/splat-loader.js`)
       loadScriptPromise.then(() => {
         Model = (window as any).Model
-        Model.setInternalConfig({workerUrl: SPLAT_WORKER_URL})
+        Model.setInternalConfig({workerUrl: `${getResourceBase()}splat/splat-worker.js`})
         finishedLoading = true
       })
     }

--- a/reality/cloud/xrhome/tools/gulp/bazel.ts
+++ b/reality/cloud/xrhome/tools/gulp/bazel.ts
@@ -46,4 +46,6 @@ export {
   wrapBazel,
   bazelBuild,
   bazelOutputFiles,
+  BAZEL_SILENT_OPTIONS,
+  BAZEL_STDOUT_ONLY_OPTIONS,
 }

--- a/reality/cloud/xrhome/tools/gulp/bazel.ts
+++ b/reality/cloud/xrhome/tools/gulp/bazel.ts
@@ -31,21 +31,9 @@ const bazelBuild = async (targets: Target | Target[], extraFlags?: string[]) => 
   ))
 )
 
-const bazelOutputFiles = async (
-  targets: Target | Target[], extraFlags?: string[]
-): Promise<string[]> => wrapBazel(async () => {
-  const out = await runChildProcess(
-    `bazel cquery --output=files ${BAZEL_STDOUT_ONLY_OPTIONS} ${formatFlags(extraFlags)} ` +
-      `-- ${formatTargets(targets)}`,
-    {cwd: CODE8, stdio: ['ignore', 'pipe', 'inherit']}
-  )
-  return out.split('\n').filter(Boolean)
-})
-
 export {
   wrapBazel,
   bazelBuild,
-  bazelOutputFiles,
   BAZEL_SILENT_OPTIONS,
   BAZEL_STDOUT_ONLY_OPTIONS,
 }

--- a/reality/cloud/xrhome/tools/gulp/bazel.ts
+++ b/reality/cloud/xrhome/tools/gulp/bazel.ts
@@ -1,31 +1,49 @@
 import {CODE8, runChildProcess} from './process'
 
 const BAZEL_SILENT_OPTIONS = '--ui_event_filters=-info,-stdout,-stderr --noshow_progress'
+const BAZEL_STDOUT_ONLY_OPTIONS = '--ui_event_filters=-info,-stderr --noshow_progress'
 
 let isBazelRunning = false
-const wrapBazel = async (fn: () => Promise<void>) => {
+const wrapBazel = async <T>(fn: () => Promise<T>): Promise<T> => {
   if (isBazelRunning) {
     throw new Error('Bazel is already running. Please ensure all bazel processes are in series()')
   }
   isBazelRunning = true
   try {
-    await fn()
+    return await fn()
   } finally {
     isBazelRunning = false
   }
 }
 
 type Target = `//${string}`
+
+const formatTargets = (targets: Target | Target[]) => (typeof targets === 'string'
+  ? targets
+  : targets.join(' '))
+
+const formatFlags = (extraFlags?: string[]) => (extraFlags ? extraFlags.join(' ') : '')
+
 const bazelBuild = async (targets: Target | Target[], extraFlags?: string[]) => (
   wrapBazel(() => runChildProcess(
-    `bazel build ${BAZEL_SILENT_OPTIONS} \
-${extraFlags ? extraFlags.join(' ') : ''} -- \
-${typeof targets === 'string' ? targets : targets.join(' ')}`,
+    `bazel build ${BAZEL_SILENT_OPTIONS} ${formatFlags(extraFlags)} -- ${formatTargets(targets)}`,
     {cwd: CODE8}
   ))
 )
 
+const bazelOutputFiles = async (
+  targets: Target | Target[], extraFlags?: string[]
+): Promise<string[]> => wrapBazel(async () => {
+  const out = await runChildProcess(
+    `bazel cquery --output=files ${BAZEL_STDOUT_ONLY_OPTIONS} ${formatFlags(extraFlags)} ` +
+      `-- ${formatTargets(targets)}`,
+    {cwd: CODE8, stdio: ['ignore', 'pipe', 'inherit']}
+  )
+  return out.split('\n').filter(Boolean)
+})
+
 export {
   wrapBazel,
   bazelBuild,
+  bazelOutputFiles,
 }

--- a/reality/cloud/xrhome/tools/gulp/process.ts
+++ b/reality/cloud/xrhome/tools/gulp/process.ts
@@ -16,7 +16,9 @@ type ChildProcessOptions = {cwd?: string, stdio?: StdioOptions}
 
 const JUST_STDERR: StdioOptions = ['ignore', 'ignore', 'inherit']
 
-const runChildProcess = (fullCommand: string, options: ChildProcessOptions = {}) => {
+const runChildProcess = (
+  fullCommand: string, options: ChildProcessOptions = {}
+): Promise<string> => {
   if (!options.stdio) {
     options.stdio = JUST_STDERR
   }
@@ -33,13 +35,15 @@ const runChildProcess = (fullCommand: string, options: ChildProcessOptions = {})
     args = parseArgsStringToArgv(fullCommand.substr(firstSpaceIndex + 1))
   }
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
     const childProcess = childDoNotUse.spawn(command, args, options)
+    let stdout = ''
+    childProcess.stdout?.on('data', (chunk) => { stdout += chunk })
     childProcess.on('exit', (code) => {
       if (code) {
         reject(new Error(`Failed to run: ${fullCommand}`))
       } else {
-        resolve()
+        resolve(stdout)
       }
     })
   })

--- a/reality/shared/studio/cdn-assets.ts
+++ b/reality/shared/studio/cdn-assets.ts
@@ -1,20 +1,12 @@
 // TODO(christoph): Migrate away from cdn.8thwall.com
 
-const DRACO_DECODER_PATH = 'https://cdn.8thwall.com/web/b/lx9h2iwd/draco/'
-
 const CIRCLE_05_URL = 'https://cdn.8thwall.com/web/assets/sprites/circle_05-m1igpyne.png'
 const EIGHTH_WALL_ICON_URL = 'https://cdn.8thwall.com/web/assets/sprites/8w-icon-m8j35d7y.png'
 const WHITE_GRAY_TILES_URL =
   'https://cdn.8thwall.com/web/assets/sprites/white_gray_tiles-m8f52fip.png'
 
-const SPLAT_MODEL_URL = 'https://cdn.8thwall.com/web/resources/model-standalone-mdgm761p.js'
-const SPLAT_WORKER_URL = 'https://cdn.8thwall.com/web/resources/model-manager-worker-mdgm761p.js'
-
 export {
-  DRACO_DECODER_PATH,
   EIGHTH_WALL_ICON_URL,
   CIRCLE_05_URL,
   WHITE_GRAY_TILES_URL,
-  SPLAT_MODEL_URL,
-  SPLAT_WORKER_URL,
 }


### PR DESCRIPTION
# Context

At the moment, several `ecs/resources` are fetched from `cdn.8thwall.com` (namely draco and splat scripts). Ideally, this repo can provide those resources locally.

This PR updates the `copyEcsResources` to source the `//c8/ecs/resources` into `reality/cloud/xrhome/desktop-dist/ecs-resources/` for electron app builds:
- Updates `bazel.ts` and `process.ts` to easily get the list of declared outputs
  - One could argue just doing a raw `bazel build ...` and `cp` might be better. I figured the generality provided by `cquery --output=files` could be nice. Though, you do need to sync paths relative to `/c8/ecs/resources`.
- Replace uses of constants from `cdn-assets` with `${getResourceBase()}/...` to follow the pattern set by other files

Example:
`bazel cquery --output=files --ui_event_filters=-info,-stderr --noshow_progress --config=wasmreleasesimd -- //c8/ecs/resources`

<details>

<summary>ECS Resources List </summary>

```
c8/ecs/resources/draco/LICENSE
c8/ecs/resources/draco/draco_decoder.js
c8/ecs/resources/draco/draco_decoder.wasm
c8/ecs/resources/draco/draco_wasm_wrapper.js
c8/ecs/resources/fonts/baskerville/baskerville.png
c8/ecs/resources/fonts/baskerville/baskerville.ttf
c8/ecs/resources/fonts/baskerville/baskerville.json
c8/ecs/resources/fonts/baskerville/LICENSE
c8/ecs/resources/fonts/futura/futura.png
c8/ecs/resources/fonts/futura/futura.ttf
c8/ecs/resources/fonts/futura/futura.json
c8/ecs/resources/fonts/futura/LICENSE
c8/ecs/resources/fonts/inconsolata/inconsolata.png
c8/ecs/resources/fonts/inconsolata/inconsolata.ttf
c8/ecs/resources/fonts/inconsolata/inconsolata.json
c8/ecs/resources/fonts/inconsolata/LICENSE
c8/ecs/resources/fonts/nanum_pen_script/nanum_pen_script.png
c8/ecs/resources/fonts/nanum_pen_script/nanum_pen_script.ttf
c8/ecs/resources/fonts/nanum_pen_script/nanum_pen_script.json
c8/ecs/resources/fonts/nanum_pen_script/LICENSE
c8/ecs/resources/fonts/nunito/nunito.png
c8/ecs/resources/fonts/nunito/nunito.ttf
c8/ecs/resources/fonts/nunito/nunito.json
c8/ecs/resources/fonts/nunito/LICENSE
c8/ecs/resources/fonts/press_start_2p/press_start_2p.png
c8/ecs/resources/fonts/press_start_2p/press_start_2p.ttf
c8/ecs/resources/fonts/press_start_2p/press_start_2p.json
c8/ecs/resources/fonts/press_start_2p/LICENSE
c8/ecs/resources/fonts/roboto/roboto.png
c8/ecs/resources/fonts/roboto/roboto.ttf
c8/ecs/resources/fonts/roboto/roboto.json
c8/ecs/resources/fonts/roboto/LICENSE
bazel-out/wasm32-opt/bin/c8/ecs/resources/splat/splat-loader.js
bazel-out/wasm32-opt/bin/c8/ecs/resources/splat/splat-worker.js
```

</details>

# Test

Read through `CONTRIBUTING.md` 😉 

## npm package

Sanity check that this path works with the new asset strings:

`./tools/prepare.sh`

Created a small non-studio project:

<details>

<summary>Entry Code</summary>

```
import * as ecs from '@8thwall/ecs'

const SPLAT_URL = '/assets/scene_v3.spz'

const sceneGraph = {
  objects: {
    'splat-1': {
      id: 'splat-1',
      name: 'Splat',
      position: [0, 0, 0],
      rotation: [1, 0, 0, 0],
      scale: [1, 1, 1],
      components: {},
      splat: {
        src: {type: 'url', url: SPLAT_URL},
        skybox: false,
      },
    },
    'ambient-light': {
      id: 'ambient-light',
      name: 'Ambient Light',
      position: [0, 0, 0],
      rotation: [0, 0, 0, 1],
      scale: [1, 1, 1],
      components: {},
      light: {type: 'ambient'},
    },
  },
}

const main = async () => {
  const e = ecs as any
  await e.application.init(sceneGraph)
  const world = e.application.getWorld()

  const camera = world.createEntity()
  e.Camera.set(world, camera, {type: 'perspective'})
  e.Position.set(world, camera, {x: 0, y: 2, z: 5})
  e.Quaternion.set(world, camera, e.math.quat.pitchYawRollDegrees({x: 20, y: 180, z: 0}))
  world.camera.setActiveEid(camera)
}

main().catch(console.error)
```

</details>

`npm run serve`

Result:

<img width="1728" height="961" alt="Screenshot 2026-05-07 at 7 39 52 PM" src="https://github.com/user-attachments/assets/028867af-5904-44a5-a521-2513e094ab14" />

Network tab shows:
`http://localhost:7777/external/runtime/resources/splat/splat-loader.js`

## Electron App

Terminal A:
`npm run dev:desktop:hot`

Terminal B:
`npm run app:start`

|Draco Loads|Splat Loads|
|-|-|
|<img width="1712" height="1135" alt="Screenshot 2026-05-07 at 9 44 36 PM" src="https://github.com/user-attachments/assets/20d9d015-c311-46ee-b1c2-49299ac40182" />|<img width="1712" height="1135" alt="Screenshot 2026-05-07 at 7 00 27 PM" src="https://github.com/user-attachments/assets/f8cc2309-8b95-4d05-94e5-3c85b492918f" />|

Let me know if there are other things I should check!