### PR TITLE
[xrhome] Fix font dropdown preview

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/configuration/ui/text-group.tsx
+++ b/reality/cloud/xrhome/src/client/studio/configuration/ui/text-group.tsx
@@ -37,7 +37,7 @@ const FontOption: React.FC<IFontOption> = ({option}) => {
   // Font name cannot have special chars used in our asset path (for font8 files). We use option
   // value so there is no collision if the font has the same name but a different path in assets/.
   // e.g. assets_PixelifySans-VariableFont_wght_font8 is ok but the original version is not.
-  const fontName = option.value.replace(/[/.]/g, '_')
+  const quotedName = `'${option.value.replace(/[/.]/g, '_')}'`
 
   // Even though style is removed and added when unmounted, network tab showed that the ttf file is
   // redownloaded.
@@ -45,12 +45,12 @@ const FontOption: React.FC<IFontOption> = ({option}) => {
     <div>
       <style>{`
         @font-face {
-          font-family: '${fontName}';
-          src: local('${fontName}'), url('${uiFont.ttf}');
-      `}
+          font-family: ${quotedName};
+          src: url('${uiFont.ttf}');
+      }`}
       </style>
 
-      <span style={{fontFamily: fontName}}>{option.content}</span>
+      <span style={{fontFamily: quotedName}}>{option.content}</span>
     </div>
   )
 }


### PR DESCRIPTION
## Context

Randomly noticed this. Seems like the `2` in the font name messes with css parsing, it's expecting it to be quoted. Also noticed a missing trailing `}` in the style element,  and dropping the local option, fixes any theoretical false matches and always uses the source.

## Testing


| Before | After |
| ------ | ------ |
|    <img width="208" height="268" alt="Screenshot 2026-05-11 at 12 40 55 PM" src="https://github.com/user-attachments/assets/5aca469b-89f2-4317-ac3d-a451d6566783" />    |     <img width="266" height="262" alt="Screenshot 2026-05-11 at 12 38 52 PM" src="https://github.com/user-attachments/assets/4e1bbe7c-e353-4684-9317-c2548e176db6" />   |

