### PR TITLE
[desktop] Enable pointerLock permission

### DIFF
--- a/apps/desktop/app/desktop-app/permissions.ts
+++ b/apps/desktop/app/desktop-app/permissions.ts
@@ -1,9 +1,8 @@
 import type {BrowserWindow} from 'electron'
 
 const registerPermissionHandler = (win: BrowserWindow) => {
+  const allowedPermissions = ['media', 'geolocation', 'pointerLock']
   win.webContents.session.setPermissionRequestHandler((_, permission, callback) => {
-    const allowedPermissions = ['media', 'geolocation']
-
     // NOTE(lreyna): We can add more logic here to allow/block based on different factors.
     // In the future we may want to check the requesting URL origin.
     // For now, we can just auto grant permissions. OSX will still prompt users on the app level.


### PR DESCRIPTION
## Context

Noticed that the image target simulator mode, which uses right click to angle the camera, was failing. 

## Testing

| Before | After |
| ------ | ------ |
| Error when right clicking | Can right click and use the mouse to tilt the camera |
|  <img width="981" height="913" alt="Screenshot 2026-05-11 at 2 19 38 PM" src="https://github.com/user-attachments/assets/093b41d8-a4e3-40c2-a8fb-5dbca7fe5296" />  |      <img width="995" height="985" alt="Screenshot 2026-05-11 at 2 16 22 PM" src="https://github.com/user-attachments/assets/90d9b904-ca16-40f5-971b-c2d646c922ca" />  |