### PR TITLE
[xrhome] Hide fog in perspective or unlit viewport modes

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/scene-edit.tsx
+++ b/reality/cloud/xrhome/src/client/studio/scene-edit.tsx
@@ -353,6 +353,12 @@ const SceneEdit: React.FC<ISceneEdit> = ({
 
   const selectedCamera = selectedObjects.find(obj => obj.camera)
 
+  const fogVisible = (
+    !isIsolated &&
+    stateCtx.state.cameraView === 'perspective' &&
+    stateCtx.state.shadingMode === 'shaded'
+  )
+
   const sceneInterfaceCtx: SceneInterface = {
     focusObject: handleFocusObject,
     cameraLookAt: (position) => {
@@ -555,7 +561,7 @@ const SceneEdit: React.FC<ISceneEdit> = ({
                         sky={sky}
                         isIsolated={isIsolated}
                       />
-                      {!isIsolated &&
+                      {fogVisible &&
                         <>
                           <SceneEnvironment reflectionsUrl={reflectionsUrl} />
                           <SceneFog fog={fog} />


### PR DESCRIPTION
## Context

Using fog on an orthographic camera doesn't work very well. User expectation would probably be that unlit mode also does not apply the fog effect.


## Testing

### Before

https://github.com/user-attachments/assets/b82c7f62-135a-4d42-bf43-1977142b966c



### After

https://github.com/user-attachments/assets/3f6146a9-09ba-4b15-96b7-44c44c02cc47



