### PR TITLE
[xrhome] Fix pivot edit behavior

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/configuration/asset-mesh-configurator.tsx
+++ b/reality/cloud/xrhome/src/client/studio/configuration/asset-mesh-configurator.tsx
@@ -373,7 +373,13 @@ const AssetMeshConfigurator: React.FC<IAssetMeshConfigurator> = ({
     auxScene.removeChild(auxNode)
     auxScene.setName(auxNode.getName())
 
+    // NOTE(christoph): If we'd adjusted the model scale/pivot, auxNode will have a non-identity
+    // transform. Since we're throwing away that node, we need to apply the transform to its
+    // children instead.
+    const rootTransform = new Matrix4().fromArray(auxNode.getMatrix())
     for (const child of auxNode.listChildren()) {
+      const newMatrix = new Matrix4().fromArray(child.getMatrix()).premultiply(rootTransform)
+      child.setMatrix(newMatrix.toArray())
       auxScene.addChild(child)
     }
 


### PR DESCRIPTION
## Context

Looks like a fix for infinite nesting broke pivot/scale transforms. 

## Testing

### Before

https://github.com/user-attachments/assets/21d06e8e-030e-418e-990f-1886fa7cc46c

### After



https://github.com/user-attachments/assets/930c91af-7cee-48c5-8d31-5af106a80827


