### PR TITLE
[xrhome] Display build errors in publish modal

### DIFF
--- a/reality/cloud/xrhome/src/client/editor/modals/nae/export-flow-html.tsx
+++ b/reality/cloud/xrhome/src/client/editor/modals/nae/export-flow-html.tsx
@@ -13,6 +13,10 @@ import {PrimaryButton} from '../../../ui/components/primary-button'
 import {SupportedPlatforms} from './supported-platforms'
 import {buildZip} from '../../../studio/local-sync-api'
 import {downloadBlob} from '../../../common/download-utils'
+import {useLogStreams} from '../../logs/use-log-streams'
+import {SYSTEM_STREAM_NAME} from '../../logs/log-constants'
+import CopyableBlock from '../../../widgets/copyable-block'
+import {StaticBanner} from '../../../ui/components/banner'
 
 interface IExportFlowHtml {
   onClose: () => void
@@ -25,17 +29,33 @@ const ExportFlowHtml: React.FC<IExportFlowHtml> = () => {
   const dispatch = useDispatch()
   const [isBuilding, setIsBuilding] = React.useState(false)
   const [currentStep, setCurrentStep] = React.useState<Steps>('start')
+  const [buildStartTime, setBuildStartTime] = React.useState(0)
+  const [buildCompleteTime, setBuildCompleteTime] = React.useState(0)
+  const [buildFailed, setBuildFailed] = React.useState(false)
+
+  const systemLogs = useLogStreams(appKey).find(e => buildFailed && e.name === SYSTEM_STREAM_NAME)
+
+  const buildLogs = systemLogs
+    ? systemLogs.logs
+      .filter(({timestamp}) => timestamp > buildStartTime &&
+      (!buildCompleteTime || timestamp < buildCompleteTime))
+      .map(e => e.text).join('\n')
+    : ''
 
   const handleExport = async () => {
     dispatch({type: 'ERROR', msg: null})
     setIsBuilding(true)
     try {
+      setBuildStartTime(Date.now())
+      setBuildCompleteTime(0)
+      setBuildFailed(false)
       const blob = await buildZip(appKey)
       const time = new Date().toISOString().replace(/[:.-]/g, '')
       downloadBlob(blob, `html-export-${time}.zip`)
     } catch (err) {
-      dispatch({type: 'ERROR', msg: t('editor_page.export_modal.html_export.build_error')})
+      setBuildFailed(true)
     } finally {
+      setBuildCompleteTime(Date.now())
       setIsBuilding(false)
     }
   }
@@ -104,6 +124,15 @@ const ExportFlowHtml: React.FC<IExportFlowHtml> = () => {
             {name: 'Viverse', url: 'https://8th.io/offline-html-export-viverse'},
           ]}
         />
+
+        {buildFailed &&
+          <>
+            <StaticBanner type='danger'>
+              {t('editor_page.export_modal.html_export.build_error')}
+            </StaticBanner>
+            {buildLogs && <CopyableBlock text={buildLogs} description='' />}
+          </>
+        }
       </div>
     </PublishPageWrapper>
   )

--- a/reality/cloud/xrhome/src/client/editor/modals/nae/ios-signing-page.tsx
+++ b/reality/cloud/xrhome/src/client/editor/modals/nae/ios-signing-page.tsx
@@ -360,7 +360,7 @@ const NaeRowUploadDrop: React.FC<INaeRowUploadDrop> = ({
             {file.name}
           </div>
           <IconButton
-            text={t('button.close')}
+            text={t('button.close', {ns: 'common'})}
             stroke='close'
             size={0.625}
             onClick={(event) => {

--- a/reality/cloud/xrhome/src/client/editor/modals/universal-publish-modal.tsx
+++ b/reality/cloud/xrhome/src/client/editor/modals/universal-publish-modal.tsx
@@ -65,20 +65,18 @@ const useStyles = createThemedStyles(theme => ({
   },
   mainContent: {
     display: 'flex',
-    padding: '1rem 1.5rem 1.5rem 0rem',
+    minWidth: 0,
+    padding: '1rem 1rem 1rem 0rem',
     flexDirection: 'column',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
     flex: '1 0 0',
+    overflow: 'hidden',
     alignSelf: 'stretch',
-    [mobileViewOverride]: {
-      overflow: 'hidden',
-      flex: '1 1 100%',
-    },
   },
   sidebar: {
-    flex: '1 1 20%',
-    maxWidth: '200px',
+    flex: '0 0 auto',
+    width: '200px',
     display: 'flex',
     padding: '1rem 0.75rem',
     flexDirection: 'column',
@@ -203,7 +201,7 @@ const UniversalPublishModal: React.FC<IPublishModal> = ({
         <div className={classes.universalPublishModal}>
           <div className={classes.closeButton}>
             <IconButton
-              text={t('button.close')}
+              text={t('button.close', {ns: 'common'})}
               stroke='close'
               size={0.625}
               onClick={collapse}


### PR DESCRIPTION
## Context

Follow up to https://github.com/8thwall/8thwall/pull/154

## Testing


<img width="1040" height="786" alt="Screenshot 2026-05-12 at 4 08 30 PM" src="https://github.com/user-attachments/assets/20dd3f9d-fa5f-45f5-a7fb-7f5325c24068" />

Now I can see the error without having to search for it:

<img width="686" height="178" alt="Screenshot 2026-05-12 at 4 06 43 PM" src="https://github.com/user-attachments/assets/4ac2e285-9aa5-482b-83f1-136dbb7e07c2" />
