### PR TITLE
[xrhome] Remove map primitive option

### DIFF
--- a/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
+++ b/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
@@ -698,7 +698,6 @@
   "new_primitive_button.option.face": "Face",
   "new_primitive_button.option.image_target": "Image Target",
   "new_primitive_button.option.location": "Location",
-  "new_primitive_button.option.map": "Map",
   "new_primitive_button.option.more": "More",
   "new_primitive_button.option.ui": "UI Element",
   "new_primitive_button.option.light": "Lights",

--- a/reality/cloud/xrhome/src/client/studio/make-object.ts
+++ b/reality/cloud/xrhome/src/client/studio/make-object.ts
@@ -14,7 +14,6 @@ import type {
   StaticImageTargetOrientation,
   PolyhedronGeometry,
   TorusGeometry,
-  MapPoint,
 } from '@ecs/shared/scene-graph'
 import type {DeepReadonly} from 'ts-essentials'
 
@@ -22,8 +21,6 @@ import {DEFAULT_MATERIAL_COLOR} from '@ecs/shared/material-constants'
 
 import {inferResourceObject} from '@ecs/shared/resource'
 import type {ParticlesSchema} from '@ecs/runtime'
-import {THEME_PRESETS, MAP_DEFAULTS} from '@ecs/shared/map-constants'
-import type {MapPointOverrides} from '@ecs/shared/map-controller'
 
 import {CIRCLE_05_URL} from '../../shared/studio/cdn-assets'
 
@@ -308,25 +305,6 @@ const makeLocation = (
   })
 }
 
-const makeMap = (parentId: string, objectName: string): GraphObject => ({
-  ...makeEmptyObject(parentId),
-  name: objectName,
-  map: {...MAP_DEFAULTS},
-  mapTheme: {...THEME_PRESETS.natural},
-})
-
-const makeMapPoint = (
-  parentId: string,
-  objectName: string,
-  mapPoint: MapPoint,
-  overrides: MapPointOverrides
-): GraphObject => ({
-  ...makeEmptyObject(parentId),
-  name: objectName,
-  mapPoint,
-  ...overrides,
-})
-
 const makeParticles = (): Partial<ParticlesSchema> => ({
   emitterLife: 0,
   particlesPerShot: 20,
@@ -379,8 +357,6 @@ export {
   makeFaceMeshObject,
   makeImageTarget,
   makeLocation,
-  makeMap,
-  makeMapPoint,
   makeParticles,
   PrimaryGeometryTypes,
   SecondaryGeometryTypes,

--- a/reality/cloud/xrhome/src/client/studio/new-primitive-button.tsx
+++ b/reality/cloud/xrhome/src/client/studio/new-primitive-button.tsx
@@ -8,7 +8,7 @@ import type {SceneContext} from './scene-context'
 import {SelectMenu} from './ui/select-menu'
 import {
   PrimaryGeometryTypes, SecondaryGeometryTypes, LightTypes, makeEmptyObject, makePrimitive,
-  makeCamera, makeFace, makeMap, makeImageTarget,
+  makeCamera, makeFace, makeImageTarget,
 } from './make-object'
 import {Icon, IconStroke} from '../ui/components/icon'
 import {SpaceBetween} from '../ui/layout/space-between'
@@ -184,14 +184,6 @@ const createNewPrimitiveOptions = (
     )),
   }
 
-  const mapOption: MenuOption = createPrimitiveOption(
-    t('new_primitive_button.option.map'),
-    () => createAndSelectObject(
-      makeMap(newObjectParentId, t('new_primitive_button.option.map')),
-      ctx, stateCtx, makePrefab
-    ), 'mapOutline'
-  )
-
   const imageTargetOption: MenuOption = createPrimitiveOption(
     t('new_primitive_button.option.image_target'),
     () => handleNewPrimitive('imageTarget'), 'imageTarget'
@@ -214,8 +206,6 @@ const createNewPrimitiveOptions = (
     imageTargetOption,
     divider,
     uiMenuOptions,
-    divider,
-    mapOption,
   ]
 }
 


### PR DESCRIPTION
## Context

The map component is no longer supported in the offline desktop

## Testing

| Before | After | 
| :- | :- |
| <img width="214" height="533" alt="Screenshot 2026-05-13 at 2 04 55 PM" src="https://github.com/user-attachments/assets/de0c0284-a73e-489c-88ae-2bbd06772faa" /> |    <img width="242" height="506" alt="Screenshot 2026-05-13 at 12 36 52 PM" src="https://github.com/user-attachments/assets/3c01a593-357c-41c4-a33d-6cd7b8f2c154" /> |