### PR TITLE
[dev8] Enable websocket by default

### DIFF
--- a/packages/dev8/src/dev8.ts
+++ b/packages/dev8/src/dev8.ts
@@ -23,14 +23,8 @@ declare global {
 
 const {
   ua, debugFlag, debugHudKey, deviceId, sessionId, simulatorConfig,
-  simulatorRendererConfig, simulatorId, originalUrl, channel,
+  simulatorRendererConfig, simulatorId, originalUrl, webSocketUrl,
 } = loadParameters()
-
-const webSocketUrl = channel && `${channel}?${new URLSearchParams({
-  sessionId,
-  deviceId,
-  ua,
-})}`
 
 const studioEventStream = createStudioEventStreamManager(webSocketUrl)
 const studioDebug = createStudioDebugManager(

--- a/packages/dev8/src/parameters.ts
+++ b/packages/dev8/src/parameters.ts
@@ -4,7 +4,6 @@ const DEBUG_PARAM = 'd'
 const SIMULATOR_PARAM = 'simulatorConfig'
 const SESSION_PARAM = 'sessionId'
 const DEBUG_KEY_PREFIX = '8w.debug-mode/'
-const CHANNEL_PARAM = 'channel'
 const KEY = 'hot-reload-deviceid'
 
 const loadParameters = () => {
@@ -20,7 +19,6 @@ const loadParameters = () => {
   // Scope local storage keys by appkey
   const debugHudKey = DEBUG_KEY_PREFIX + deviceId
   const params = new URLSearchParams(window.location.search)
-  const channel = params.get(CHANNEL_PARAM)
 
   const simulatorConfigParam = params.get(SIMULATOR_PARAM)
   const simulatorConfig: SimulatorConfig | null = simulatorConfigParam
@@ -47,6 +45,12 @@ const loadParameters = () => {
     window.history.replaceState(null, '', `${window.location.pathname}?${params}`)
   }
 
+  const webSocketUrl = params.get('liveSyncMode') === 'inline'
+    ? null
+    : `/dev8?${new URLSearchParams({
+      sessionId,
+    })}`
+
   let debugFlagParam
   if (params.has(DEBUG_PARAM)) {
   // This is present as ?d=true if the HUD is enabled.
@@ -58,7 +62,7 @@ const loadParameters = () => {
   const debugFlag = debugFlagParam === 'true'
 
   // Clear the parameters so that users don't see it in their url
-  const paramsToClear = [DEBUG_PARAM, SIMULATOR_PARAM, CHANNEL_PARAM]
+  const paramsToClear = [DEBUG_PARAM, SIMULATOR_PARAM]
   if (paramsToClear.some(p => params.has(p))) {
     const replacedUrl = new URL(originalUrl)
     paramsToClear.forEach(p => replacedUrl.searchParams.delete(p))
@@ -66,7 +70,7 @@ const loadParameters = () => {
   }
 
   return {
-    channel,
+    webSocketUrl,
     ua,
     deviceId,
     sessionId,


### PR DESCRIPTION
## Context

Follow up to https://github.com/8thwall/8thwall/pull/167

Other than for the inline simulator, we open a websocket to the /dev8 path on the same origin as the current path. This should work with all forms of local server, ngrok, proxy, etc.

## Testing

Can send and receive messages over the websocket

<img width="761" height="198" alt="Screenshot 2026-05-15 at 6 29 47 PM" src="https://github.com/user-attachments/assets/579e3891-f807-4fe3-858a-8a2febf1bd9b" />

