### PR TITLE
[xrhome][desktop] Add fixup recommendation for websocket connection

### DIFF
--- a/apps/desktop/app/file-sync/project-handler-types.ts
+++ b/apps/desktop/app/file-sync/project-handler-types.ts
@@ -22,7 +22,7 @@ type IMoveProjectParams = z.infer<typeof MoveProjectParams>
 
 const FixConfigParams = z.object({
   appKey: z.string(),
-  fix: z.enum(['inject', 'copy-plugin']),
+  fix: z.enum(['inject', 'copy-plugin', 'dev-socket']),
 })
 
 type IFixConfigParams = z.infer<typeof FixConfigParams>

--- a/apps/desktop/app/file-sync/project-handler.ts
+++ b/apps/desktop/app/file-sync/project-handler.ts
@@ -690,6 +690,23 @@ const GOOD_COPY_PLUGIN_CONFIG = `\
         },
       ],`
 
+const BAD_DEV_SOCKET_CONFIG = `\
+    client: {
+      overlay: {
+        warnings: false,
+        errors: true,
+      },
+    },`
+
+const GOOD_DEV_SOCKET_CONFIG = `\
+    client: {
+      webSocketURL: 'ws://0.0.0.0/ws',
+      overlay: {
+        warnings: false,
+        errors: true,
+      },
+    },`
+
 const WEBPACK_CONFIG_PATH = 'config/webpack.config.js'
 
 const getProjectConfig = withErrorHandlingResponse(async (req: Request) => {
@@ -710,12 +727,14 @@ const getProjectConfig = withErrorHandlingResponse(async (req: Request) => {
 
   let needsInjectFix = false
   let needsCopyPluginFix = false
+  let needsDevSocketFix = false
   let missingDev8 = false
   try {
     const configPath = path.join(project.location, WEBPACK_CONFIG_PATH)
     const configContent = await fs.readFile(configPath, 'utf-8')
     needsInjectFix = configContent.includes(BAD_INJECT_CONFIG)
     needsCopyPluginFix = configContent.includes(BAD_COPY_PLUGIN_CONFIG)
+    needsDevSocketFix = configContent.includes(BAD_DEV_SOCKET_CONFIG)
     missingDev8 = !configContent.includes('dev8')
   } catch (error) {
     // Ignore
@@ -725,6 +744,7 @@ const getProjectConfig = withErrorHandlingResponse(async (req: Request) => {
     needsInjectFix,
     needsCopyPluginFix,
     missingDev8,
+    needsDevSocketFix,
   }
 
   return makeJsonResponse(response)
@@ -755,6 +775,13 @@ const modifyProjectConfig = withErrorHandlingResponse(async (req: Request) => {
       const configPath = path.join(project.location, WEBPACK_CONFIG_PATH)
       const configContent = await fs.readFile(configPath, 'utf-8')
       const fixedContent = configContent.replace(BAD_COPY_PLUGIN_CONFIG, GOOD_COPY_PLUGIN_CONFIG)
+      await fs.writeFile(configPath, fixedContent, 'utf-8')
+      break
+    }
+    case 'dev-socket': {
+      const configPath = path.join(project.location, WEBPACK_CONFIG_PATH)
+      const configContent = await fs.readFile(configPath, 'utf-8')
+      const fixedContent = configContent.replace(BAD_DEV_SOCKET_CONFIG, GOOD_DEV_SOCKET_CONFIG)
       await fs.writeFile(configPath, fixedContent, 'utf-8')
       break
     }

--- a/apps/desktop/new-project/config/webpack.config.js
+++ b/apps/desktop/new-project/config/webpack.config.js
@@ -84,6 +84,7 @@ const config = {
       'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization',
     },
     client: {
+      webSocketURL: 'ws://0.0.0.0/ws',
       overlay: {
         warnings: false,
         errors: true,

--- a/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
+++ b/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
@@ -734,6 +734,7 @@
   "recommendation_box.update_references": "Update references",
   "recommendation_box.inject_message": "This project is missing a required configuration change in config/webpack.config.js.",
   "recommendation_box.copy_plugin_message": "Asset configuration was mistakenly left out of the project template in config/webpack.config.js.",
+  "recommendation_box.dev_socket_message": "To improve device preview, a tweak is recommended to your webpack configuration.",
   "recommendation_box.fix": "Apply Fix",
   "recommendation_box.dismiss": "Dismiss",
   "reflection.menu.label.url": "URL",

--- a/reality/cloud/xrhome/src/client/studio/local-sync-api.ts
+++ b/reality/cloud/xrhome/src/client/studio/local-sync-api.ts
@@ -339,7 +339,7 @@ const checkConfigStatus = (appKey: string) => {
   )
 }
 
-const applyProjectConfigFix = (appKey: string, fix: 'inject' | 'copy-plugin') => {
+const applyProjectConfigFix = (appKey: string, fix: 'inject' | 'copy-plugin' | 'dev-socket') => {
   const params = new URLSearchParams({
     appKey,
     fix,

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -183,11 +183,46 @@ const CopyPluginFixRecommendation = () => {
   )
 }
 
+const DevSocketFixRecommendation = () => {
+  const {t} = useTranslation(['cloud-studio-pages', 'common'])
+  const {appKey} = useCurrentApp()
+  const localSyncContext = useLocalSyncContext()
+  const status = useQuery(getProjectConfigStatusQuery(appKey)).data
+  const needsDevSocketFix = status?.needsDevSocketFix && !status.missingDev8
+  const [dismissed, setDismissed] = React.useState(false)
+  const visible = needsDevSocketFix && !dismissed
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <StaticBanner type='warning'>
+      <SpaceBetween direction='vertical'>
+        {t('recommendation_box.dev_socket_message')}
+        <SpaceBetween>
+          <BoldButton onClick={async () => {
+            await applyProjectConfigFix(appKey, 'dev-socket')
+            await localSyncContext.restartServer()
+          }}
+          >
+            {t('recommendation_box.fix')}
+          </BoldButton>
+          <BoldButton onClick={() => setDismissed(true)}>
+            {t('recommendation_box.dismiss')}
+          </BoldButton>
+        </SpaceBetween>
+      </SpaceBetween>
+    </StaticBanner>
+  )
+}
+
 const RecommendationBox = () => (
   <>
     <AssetBundleRecommendation />
     <WebpackInjectFixRecommendation />
     <CopyPluginFixRecommendation />
+    <DevSocketFixRecommendation />
   </>
 )
 

--- a/reality/shared/desktop/local-sync-types.ts
+++ b/reality/shared/desktop/local-sync-types.ts
@@ -93,6 +93,7 @@ type InstallRequest = {
 type ProjectConfigResponse = {
   needsInjectFix: boolean
   needsCopyPluginFix: boolean
+  needsDevSocketFix: boolean
   missingDev8: boolean
 }
 


### PR DESCRIPTION
## Context

Follow up to https://github.com/8thwall/8thwall/pull/167

Webpack by default tries to connect to localhost on the same port it's running in, but in the case of the server being proxied through ngrok to another device, that wouldn't be the correct URL.

This option instructs webpack to use the `/ws` url on the current origin. This makes it work on localhost, direct IP, and ngrok like on https://github.com/8thwall/8thwall/pull/170

## Testing


<img width="314" height="292" alt="Screenshot 2026-05-18 at 1 29 59 PM" src="https://github.com/user-attachments/assets/e2db2e65-b306-4912-9cca-679e4a830d20" />

- With this change, webpack hot reload works on remote devices


