### PR TITLE
[dev8] Switch away from URL for restoring session ID

### DIFF
--- a/packages/dev8/src/parameters.ts
+++ b/packages/dev8/src/parameters.ts
@@ -6,6 +6,14 @@ const SESSION_PARAM = 'sessionId'
 const DEBUG_KEY_PREFIX = '8w.debug-mode/'
 const KEY = 'hot-reload-deviceid'
 
+// When we're unloading, store the session ID so it can be reused when the page is reloaded.
+// If two tabs are loaded in the same browser, they will not get the same session ID because
+// it gets removed from the list while the page is open. Only between refreshes, or after closing
+// the tab does it get added to the pool. Technically this could cause two tabs in the same browser
+// to swap session IDs if they refresh at the exact same time, but not the worst thing ever,
+// if it does happen.
+const SESSION_POOL_KEY = 'session-id-pool'
+
 const loadParameters = () => {
   /* Get a random persistent nonce to identify this browser */
   let deviceId = localStorage.getItem(KEY)
@@ -37,12 +45,18 @@ const loadParameters = () => {
 
   // For simulator sessions, this will always be provided in the params.
   let sessionId = params.get(SESSION_PARAM)
+  const sessionDerivedFromUrl = !!sessionId
   if (!sessionId) {
-    sessionId = Array.from({length: 8})
-      .map(() => Math.floor(Math.random() * 36).toString(36))
-      .join('')
-    params.set(SESSION_PARAM, sessionId)
-    window.history.replaceState(null, '', `${window.location.pathname}?${params}`)
+    const availableSessionIds = localStorage.getItem(SESSION_POOL_KEY)
+    if (availableSessionIds) {
+      const [firstSessionId, ...otherSessionIds] = availableSessionIds.split(',')
+      sessionId = firstSessionId
+      localStorage.setItem(SESSION_POOL_KEY, otherSessionIds.join(','))
+    } else {
+      sessionId = Array.from({length: 8})
+        .map(() => Math.floor(Math.random() * 36).toString(36))
+        .join('')
+    }
   }
 
   const webSocketUrl = params.get('liveSyncMode') === 'inline'
@@ -68,6 +82,16 @@ const loadParameters = () => {
     paramsToClear.forEach(p => replacedUrl.searchParams.delete(p))
     window.history.replaceState(null, '', replacedUrl.toString())
   }
+
+  window.addEventListener('beforeunload', () => {
+    if (sessionDerivedFromUrl) {
+      return
+    }
+    localStorage.setItem(SESSION_POOL_KEY, [
+      sessionId,
+      localStorage.getItem(SESSION_POOL_KEY),
+    ].filter(Boolean).join(','))
+  })
 
   return {
     webSocketUrl,


### PR DESCRIPTION
## Context

Part of #118 

Previously, dev8 would add a session ID to every connected device which could be a bit distracting and unwanted.

We want each separate tab to have its own session ID, but we still want to retain the same session ID when the tab is refreshed, or closed or reopened. We'll "release" a session ID when closing a tab, storing it in the pool, then pop it back off when reopening. This prevents multiple tabs from getting the same session ID, but retains it between refreshes.

## Testing

Starting with two ids in the pool:

<img width="638" height="38" alt="Screenshot 2026-05-18 at 2 02 10 PM" src="https://github.com/user-attachments/assets/47c028bc-ff15-4bb5-9c73-ba454cf01704" />

Opening a browser tab takes the id and removes it from the pool:

<img width="548" height="53" alt="Screenshot 2026-05-18 at 2 02 16 PM" src="https://github.com/user-attachments/assets/b0d2a406-b1a9-4570-b678-387d1b95c82e" />

Opening another tab takes the remaining ID:

<img width="567" height="30" alt="Screenshot 2026-05-18 at 2 05 44 PM" src="https://github.com/user-attachments/assets/7278bd92-2e65-4e8a-aeef-a8b061e57b3a" />


Closing that first tab returns its session ID to the pool:

<img width="537" height="36" alt="Screenshot 2026-05-18 at 2 02 24 PM" src="https://github.com/user-attachments/assets/1fd900da-0681-45be-a6ea-825f776d5082" />


