### PR TITLE
[xrhome][desktop] Fix event handlers not being cleaned up

### DIFF
--- a/apps/desktop/app/dev8-socket/api.ts
+++ b/apps/desktop/app/dev8-socket/api.ts
@@ -25,8 +25,14 @@ const createDev8SocketApi = (): Dev8SocketApi => {
     rendererPort?.postMessage(d)
   })
 
+  let listener: null | undefined | ((d: ScopedDebugMessage) => void)
+
+  fromDevice.addListener(d => listener?.(d))
+
   return {
-    fromDevice,
+    setListener: (l) => {
+      listener = l
+    },
     toDevice,
   }
 }

--- a/reality/cloud/xrhome/src/client/editor/hooks/use-console-activity.ts
+++ b/reality/cloud/xrhome/src/client/editor/hooks/use-console-activity.ts
@@ -21,6 +21,7 @@ const useConsoleActivity = BuildIf.STUDIO_OFFLINE_LOG_CONTAINER_20260205
     const handleMessage = useEvent((msg: DebugMessage) => {
       switch (msg.action) {
         case 'CONSOLE_ACTIVITY':
+          console.log(msg)
           addEditorLogs(appKey, [ConsoleLogStreams.messageLog(msg)].flat())
           break
         case 'SESSION_START':
@@ -54,9 +55,9 @@ const useConsoleActivity = BuildIf.STUDIO_OFFLINE_LOG_CONTAINER_20260205
           handleMessage(e.data)
         }
       }
-      window.electron.dev8Socket.fromDevice.addListener(handleDevice)
+      window.electron.dev8Socket.setListener(handleDevice)
       return () => {
-        window.electron.dev8Socket.fromDevice.removeListener(handleDevice)
+        window.electron.dev8Socket.setListener(null)
       }
     }, [appKey])
   }

--- a/reality/shared/desktop/electron-api.ts
+++ b/reality/shared/desktop/electron-api.ts
@@ -1,8 +1,9 @@
+import type {ScopedDebugMessage} from '@repo/c8/ecs/src/shared/debug-messaging'
+
 import type {LocalSyncMessage} from './local-sync-types'
 import type {StudiohubProtocol} from './desktop-protocol-types'
 import type {SystemLogHandler} from './system-log-types'
-import type {ScopedDebugMessage} from '@repo/c8/ecs/src/shared/debug-messaging'
-import type {ListenerPool} from '@repo/reality/shared/listener-pool'
+import type {ListenerPool} from '../listener-pool'
 
 const ELECTRON_API_KEY = 'electron'
 
@@ -20,8 +21,8 @@ type SystemLogApi = {
 }
 
 type Dev8SocketApi = {
-  fromDevice: ListenerPool<ScopedDebugMessage>
-  toDevice: ListenerPool<ScopedDebugMessage>
+  setListener: (l: null | ((d: ScopedDebugMessage) => void)) => void
+  toDevice: Pick<ListenerPool<ScopedDebugMessage>, 'dispatch'>
 }
 
 type ElectronApi = {


### PR DESCRIPTION
## Context

We're using `exposeInMainWorld` to expose the electron ipc api: https://www.electronjs.org/docs/latest/api/context-bridge

However, the fact that we're crossing a context boundary means the assumptions made by listener-pool where addListener/removeListener add/remove from a set don't work, because passing the same function multiple times does not retain referential equality. 

As a workaround, since we only need one global instance of `useConsoleActivity` currently, we can simply reduce the API surface for now.

## Testing

The reproduction case is to open a project, go back to the project list, and reopen the project. Each time the project is exited, the listener won't be removed, so it'll hang around forever and the same event will be received multiple times. We see the `[2]` there which indicates the repeated log has been collapsed.

### Before



https://github.com/user-attachments/assets/3507be2d-70ee-4906-882b-a16c818b6c68




### After

https://github.com/user-attachments/assets/9b91fbe6-5b56-46d8-b489-93b1b805558b


