### PR TITLE
[desktop] Disable color in terminal output

### DIFF
--- a/apps/desktop/app/file-sync/run-commands.ts
+++ b/apps/desktop/app/file-sync/run-commands.ts
@@ -13,6 +13,10 @@ const EXEC_PATH = process.platform === 'darwin'
   ? process.helperExecPath
   : process.execPath.replace(/\\+$/, '')
 
+const COMMON_ENV = {
+  NO_COLOR: '1',
+}
+
 type ScriptRunOptions = {
   cwd: string
   name: 'build' | 'serve'
@@ -66,7 +70,7 @@ const runInstallCommand = async (
   const child = fork(
     NPM_CLI_PATH,
     ['install', ...(extraArguments || [])],
-    {cwd: savePath, stdio: 'pipe', env: {ELECTRON_RUN_AS_NODE: '1'}, detached: true}
+    {cwd: savePath, stdio: 'pipe', env: {...COMMON_ENV, ELECTRON_RUN_AS_NODE: '1'}, detached: true}
   )
 
   forwardProcessOutput(appKey, child)
@@ -112,6 +116,7 @@ const runBuildCommand = (
   const child = runScript({
     cwd: savePath,
     name: 'build',
+    env: COMMON_ENV,
   })
 
   forwardProcessOutput(appKey, child)
@@ -139,7 +144,7 @@ const runServeCommand = (savePath: string, port: number): ChildProcess => {
   const child = runScript({
     cwd: savePath,
     name: 'serve',
-    env: {PORT: port.toString()},
+    env: {...COMMON_ENV, PORT: port.toString()},
     arguments: ['--port', `${port}`],
   })
 

--- a/reality/cloud/xrhome/src/client/i18n/en-US/cloud-editor-pages.json
+++ b/reality/cloud/xrhome/src/client/i18n/en-US/cloud-editor-pages.json
@@ -696,7 +696,7 @@
   "project_history_page.no_repo_modal.blurb": "Once you begin developing your project in the Editor, this page will display your project\u0027s commit history.",
   "remote_setup_view.initializing_server": "Initializing server",
   "remote_setup_view.recommend_ngrok": "<ngrokLink>ngrok</ngrokLink> is is the recommended way to connect your development server to a remote device:",
-  "remote_setup_view.enter_url": "ngrok, or any simular proxy, will output a remote URL which you can enter here:",
+  "remote_setup_view.enter_url": "ngrok, or any similar proxy, will output a remote URL which you can enter here:",
   "remote_setup_view.label.proxy_url": "Proxy URL",
   "remote_setup_view.option.direct_ip": "Direct IP",
   "remote_setup_view.option.proxy_server": "Proxy Server, e.g. ngrok",


### PR DESCRIPTION
## Context

Windows color support detection is different on windows, so we were getting unwanted control characters in the output.

## Testing

| Before | After |
| :- | :- |
| <img width="1652" height="518" alt="Screenshot 2026-05-18 214455" src="https://github.com/user-attachments/assets/5ac5da0f-c2e9-45d1-8c81-ff842a8c5a9e" /> | <img width="1788" height="574" alt="Screenshot 2026-05-18 220950" src="https://github.com/user-attachments/assets/91a665f6-f35c-4bbf-a574-a4f867f2b67b" /> |

 