### PR TITLE
[xrhome] Ensure bottom bar opens at minimum size

### DIFF
--- a/reality/cloud/xrhome/src/client/apps/log-container-split.tsx
+++ b/reality/cloud/xrhome/src/client/apps/log-container-split.tsx
@@ -38,7 +38,7 @@ const LogContainerSplit: React.FC<IFileEditorMainContent> = ({
   const toggleShowLogs = () => {
     setSplitSize(
       splitSize < MIN_EXPANDED_SIZE
-        ? limitSize(preferredExpandedSize)
+        ? Math.max(EXPANDED_SIZE, limitSize(preferredExpandedSize))
         : COLLAPSED_SIZE
     )
   }


### PR DESCRIPTION
## Context

Clicking a log tab causes the log container to open if it isn't already, based on preferredExpandedSize. However, it seems like somehow I got a small `preferredExpandedSize`, which was a little confusing because it barely moved when I clicked it. Now, it should open at a minimum of 250px.

## Testing

- Couldn't repro