### PR TITLE
[ecs] Fix RotateAnimation start point bookkeeping

### DIFF
--- a/c8/ecs/src/runtime/animation.ts
+++ b/c8/ecs/src/runtime/animation.ts
@@ -394,6 +394,7 @@ const RotateAnimation = registerComponent({
     if (component.schema.autoFrom) {
       setupVector3Component(world, component, getRotationCursorAsEuler)
     } else {
+      component.data.start = world.time.elapsed
       component.data.startX = degreesToRadians(component.schema.fromX)
       component.data.startY = degreesToRadians(component.schema.fromY)
       component.data.startZ = degreesToRadians(component.schema.fromZ)


### PR DESCRIPTION
## Context

`setupVector3Component` is what handles the `data.start = ...` logic for most of these components, but in this case, if `autoFrom` is false, because of radian/degree conversion, we skip that call, and `start` is left as 0 in all cases. 

## Testing

<details><summary>With this test code in demo.ts</summary>


```
const RotateAnimationTest = ecs.registerComponent({
  name: 'rotate-animation-test',
  stateMachine: ({entity, defineState}) => {
    const rotate = defineState('rotate').initial()

    const wait = defineState('wait')

    rotate.onEnter(() => {
      entity.set(ecs.RotateAnimation, {
        // autoFrom: true,
        toY: 360,
        shortestPath: false,
        duration: 800,
        loop: false,
      })
    }).onExit(() => {
      entity.remove(ecs.RotateAnimation)
    })

    rotate.wait(800, wait)
    wait.wait(500, rotate)
  },
})
...

  ecs.defineQuery([ecs.GltfModel])(world).forEach((e) => {
    console.log('setting RotateAnimationTest on', e)
    RotateAnimationTest.set(world, e)
  })
```

</details>

`bazel run //c8/ecs:serve-runtime --config=wasm`


### Before

There would only be one rotation at the start, then even though we're resetting the animation on a loop, it never restarts

### After

The rotation repeats as expected
