### PR TITLE
[xrhome] Add buffer region for log container scroll to bottom behavior

### DIFF
--- a/reality/cloud/xrhome/src/client/editor/logs/log-stream-view.tsx
+++ b/reality/cloud/xrhome/src/client/editor/logs/log-stream-view.tsx
@@ -137,7 +137,7 @@ const LogStreamView: React.FC<ILogStreamView> = ({logStream, logFilter}) => {
             return true
           }
           const currentScrollBottom = box.scrollHeight - box.scrollTop - box.clientHeight
-          return currentScrollBottom === 0
+          return currentScrollBottom < 5
         }}
         componentDidUpdateCb={(prevProps, prevState, shouldScroll) => {
           if (shouldScroll) {


### PR DESCRIPTION
## Context

Was getting an offset of 0.5 even though I had fully scrolled to the bottom. Might be window size specific.

<img width="260" height="148" alt="Screenshot 2026-05-26 at 12 43 23 PM" src="https://github.com/user-attachments/assets/081a7776-610b-4d1f-8ace-9de12215215a" />


## Testing

Scroll position properly tracked output
