### PR TITLE
fix: windows path handling in basename and dirname utilities(#196)

### DIFF
--- a/reality/cloud/xrhome/src/client/editor/editor-common.ts
+++ b/reality/cloud/xrhome/src/client/editor/editor-common.ts
@@ -7,10 +7,10 @@ const fileExt = (filename: string) => (
 const joinExt = (fileName: string, ext: string) => (
   ext ? `${fileName}.${ext}` : fileName
 )
-const basename = (filePath: string) => filePath.split('/').slice(filePath.endsWith('/')
-  ? -2
-  : -1)[0]
-const dirname = (filePath: string): string => filePath.split('/').slice(0, -1).join('/')
+const basename = (filePath: string) =>
+  filePath.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || ''
+const dirname = (filePath: string) =>
+  filePath.replace(/[\\/]+$/, '').split(/[\\/]/).slice(0, -1).join('/')
 
 export {
   fileExt,


### PR DESCRIPTION
Fixes cross-platform path handling for desktop project path utilities.

Previously, basename and dirname only handled POSIX-style (/) separators, causing incorrect basename extraction and inconsistent dirname normalization in the windows desktop project list.

This update:
supports both / and \ path separators
correctly handles trailing separators
preserves existing behavior for POSIX paths

Fixes #196