### PR TITLE
[xrhome] Prevent focus from remaining on play button

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/studio-debug-controls-tray.tsx
+++ b/reality/cloud/xrhome/src/client/studio/studio-debug-controls-tray.tsx
@@ -63,6 +63,7 @@ const StudioDebugControlsTray: React.FC<IDebugControlsTray> = ({onPlay, simulato
         ? (
           <FloatingIconButton
             id={ProductTourId.DEBUG_PLAY_PAUSE}
+            key='pause'
             isActive
             text={t('studio_play_button_tray.button.stop')}
             onClick={handleStop}
@@ -72,6 +73,7 @@ const StudioDebugControlsTray: React.FC<IDebugControlsTray> = ({onPlay, simulato
         : (
           <FloatingIconButton
             id={ProductTourId.DEBUG_PLAY_PAUSE}
+            key='play'
             text={t('studio_play_button_tray.button.play')}
             onClick={onPlay}
             stroke='play'

--- a/reality/cloud/xrhome/src/client/studio/studio-debug-controls-tray.tsx
+++ b/reality/cloud/xrhome/src/client/studio/studio-debug-controls-tray.tsx
@@ -63,6 +63,7 @@ const StudioDebugControlsTray: React.FC<IDebugControlsTray> = ({onPlay, simulato
         ? (
           <FloatingIconButton
             id={ProductTourId.DEBUG_PLAY_PAUSE}
+            // NOTE(christoph): Using unique keys to force a remount, resetting focus
             key='pause'
             isActive
             text={t('studio_play_button_tray.button.stop')}


### PR DESCRIPTION
## Context

Part of #193 

Follow up will be evaluating whether a focus indicator on the simulator is worth doing

## Testing

Pressing space after clicking play no longer closes the simulator