### PR TITLE
fix: fix basename calculation for windows in project-list-items

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/project-list-item.tsx
@@ -163,7 +163,9 @@ const ProjectListItem: React.FC<IProjectListItem> = ({project}) => {
             />
             <div className={classes.textContainer}>
               <SpaceBetween direction='vertical' narrow>
-                <span className={classes.appName}>{basename(project.location)}</span>
+                <span className={classes.appName}>
+                  {project.location.replace(/[\\/]+$/, '').split(/[\\/]/).pop()}
+                </span>
                 <span className={classes.projectLocation}>
                   {project.location}
                 </span>


### PR DESCRIPTION
## Description

Fixes incorrect project name rendering on Windows in the Desktop project's list view.
This change applies a localized path extraction in the project list item so that both Windows (`\`) and POSIX (`/`) path separators are handled correctly when displaying the project name.

Fixes #196
