### PR TITLE
[dev8] Preserve simulator params in url query

### DIFF
--- a/packages/dev8/src/parameters.ts
+++ b/packages/dev8/src/parameters.ts
@@ -107,6 +107,13 @@ const loadParameters = () => {
   }
 }
 
+const saveSimulatorConfig = (config: SimulatorConfig) => {
+  const updatedUrl = new URL(window.location.href)
+  updatedUrl.searchParams.set(SIMULATOR_PARAM, JSON.stringify(config))
+  window.history.replaceState(null, '', updatedUrl.toString())
+}
+
 export {
   loadParameters,
+  saveSimulatorConfig,
 }

--- a/packages/dev8/src/parameters.ts
+++ b/packages/dev8/src/parameters.ts
@@ -76,7 +76,7 @@ const loadParameters = () => {
   const debugFlag = debugFlagParam === 'true'
 
   // Clear the parameters so that users don't see it in their url
-  const paramsToClear = [DEBUG_PARAM, SIMULATOR_PARAM]
+  const paramsToClear = [DEBUG_PARAM]
   if (paramsToClear.some(p => params.has(p))) {
     const replacedUrl = new URL(originalUrl)
     paramsToClear.forEach(p => replacedUrl.searchParams.delete(p))

--- a/packages/dev8/src/simulator-events.ts
+++ b/packages/dev8/src/simulator-events.ts
@@ -1,6 +1,7 @@
 import type {XrSimulatorManager} from './xrsimulator/xr-simulator'
 import type {SimulatorConfig, SimulatorRendererConfig} from './xrsimulator/simulator-types'
 import {broadcastReloadConfirmation} from './xrsimulator/broadcast-messages'
+import {saveSimulatorConfig} from './parameters'
 
 const simulatorEnabledForConfig = (config: SimulatorConfig): boolean => (
   !!config?.cameraUrl || !!config?.poiId || !!config?.mockLat ||
@@ -30,6 +31,7 @@ const handleSimulatorEvents = (
         case 'SIMULATOR_CONFIG_UPDATE':
           config = event.data.data.simulatorConfig
           if (simulatorIdMatches(config?.simulatorId)) {
+            saveSimulatorConfig(config)
             if (simulatorEnabledForConfig(config)) {
             // Fire a Location Lost event when switching to a different location so that the
             // simulator stops rendering the objects of the previously selected location.


### PR DESCRIPTION
## Context

Fixes an issue where the simulator would go white after making a code change. In the cloud version of dev8, the reloads were triggered by a build completion event, which would allow dev8 to restore the original `simulatorConfig` url param before triggering the page load. 

With local websocket dev server, if we remove the param, the full page reload (triggered by a code change for example) would reload without the param. This would result in ECS_READY being sent without a simulatorId which would cause `handleDebugMessage` in `useRemoteScene` to ignore, and the device session would be waiting indefinitely for the ECS_ATTACH event.

Since the user doesn't really get exposed to the page url within the simulator, we should be good to simply leave it.

## Testing

- Can edit source files, which refreshes the page, but now continues to play.
- Changing the simulator sequence while the simulator is open, then triggering a refresh, uses the most up-to-date config after reloading (not the old state)

