### PR TITLE
[xrhome] Add non-studio editor view

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/local-studio-page.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/local-studio-page.tsx
@@ -19,7 +19,7 @@ import {LocalSyncContextProvider, useLocalSyncContext} from '../studio/local-syn
 import {FileActionsContext} from '../editor/files/file-actions-context'
 import {useStudioFileActionState} from '../studio/hooks/use-studio-file-action-state'
 import {AppPathsContext} from '../common/app-container-context'
-import {useGitRepo} from '../git/hooks/use-current-git'
+import {useGitRepo, useScopedGitFile} from '../git/hooks/use-current-git'
 import {UiThemeProvider} from '../ui/theme'
 import {FloatingNavigation} from '../studio/floating-navigation'
 import {BuildControlTray} from '../studio/build-control-tray'
@@ -47,6 +47,8 @@ import {Loader} from '../ui/components/loader'
 import {useSystemLog} from '../editor/hooks/use-system-log'
 import {useConsoleActivity} from '../editor/hooks/use-console-activity'
 import {INLINE_SIMULATOR_SESSION_ID} from '../editor/app-preview/app-preview-constants'
+import {EXPANSE_FILE_PATH} from '../studio/common/studio-files'
+import {NonStudioView} from './non-studio-view'
 
 const LocalStudioPageInner: React.FC<{appKey: string}> = () => {
   const repo = useGitRepo()
@@ -185,15 +187,19 @@ const LocalStudioPage: React.FC = () => {
     }))
   }, [appKey])
 
+  const hasExpanse = !!useScopedGitFile(appKey, EXPANSE_FILE_PATH)
+
   let res = (
     <div className={`studio-editor ${theme}`}>
-      <LocalStudioPageInner appKey={appKey} />
+      {hasExpanse ? <LocalStudioPageInner appKey={appKey} /> : <NonStudioView />}
     </div>
   )
 
   res = <PublishingStateContextProvider>{res}</PublishingStateContextProvider>
   res = <DismissibleModalContextProvider>{res}</DismissibleModalContextProvider>
-  res = <SceneDebugContext>{res}</SceneDebugContext>
+  if (hasExpanse) {
+    res = <SceneDebugContext>{res}</SceneDebugContext>
+  }
   res = <FileSyncSuspense>{res}</FileSyncSuspense>
   res = <LocalSyncContextProvider>{res}</LocalSyncContextProvider>
   res = <SceneStateContext>{res}</SceneStateContext>

--- a/reality/cloud/xrhome/src/client/desktop/non-studio-right-panel.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/non-studio-right-panel.tsx
@@ -1,0 +1,138 @@
+import React from 'react'
+import {createUseStyles} from 'react-jss'
+
+import {FloatingTray} from '../ui/components/floating-tray'
+import AssetConfigurator from '../studio/configuration/asset-configurator'
+import {FileConfigurator} from '../studio/file-configurator'
+import {PanelSelection, useStudioStateContext} from '../studio/studio-state-context'
+import {extractFilePath, extractRepoId} from '../editor/editor-file-location'
+import {useCurrentRepoId} from '../git/repo-id-context'
+import {useScopedGitFile} from '../git/hooks/use-current-git'
+import {combine} from '../common/styles'
+import {ImageTargetAssetConfigurator} from '../studio/configuration/image-target-asset-configurator'
+import {DEFAULT_ROW_INLINE_PADDING, ROW_PADDING_VAR} from '../studio/configuration/row-styles'
+import {DISCARD_ROOT_PATH, ScenePathRootProvider} from '../studio/scene-path-input-context'
+import {Loader} from '../ui/components/loader'
+import {isAssetPath} from '../common/editor-files'
+
+const RIGHT_PANEL_WIDTH = 325
+
+const useStyles = createUseStyles({
+  editPanel: {
+    overflow: 'auto',
+    width: `${RIGHT_PANEL_WIDTH}px`,
+    display: 'flex',
+    flexDirection: 'column',
+    pointerEvents: 'auto',
+    fontSize: '12px',
+    [ROW_PADDING_VAR]: BuildIf.MIGRATE_PADDING_20250610 ? DEFAULT_ROW_INLINE_PADDING : '0em',
+  },
+  mainContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: '1 0 0',
+  },
+  autoScroll: {
+    overflowY: 'auto',
+  },
+  neverScroll: {
+    overflowY: 'hidden',
+  },
+})
+
+interface IFloatingRightPanel {
+  topBar: React.ReactNode
+}
+
+const FloatingRightPanel: React.FC<IFloatingRightPanel> = ({
+  topBar,
+}) => {
+  const classes = useStyles()
+  const stateCtx = useStudioStateContext()
+  const {selectedAsset, selectedImageTarget} = stateCtx.state
+  const primaryRepoId = useCurrentRepoId()
+  const assetRepoId = extractRepoId(selectedAsset) || primaryRepoId
+  const selectedAssetFile = useScopedGitFile(assetRepoId, extractFilePath(selectedAsset))
+
+  const {currentPanelSection} = stateCtx.state
+
+  type InspectorContent = {
+    content: React.ReactNode
+    containerClass: string
+  }
+
+  const renderInspector = (): null | InspectorContent => {
+    if (selectedAssetFile) {
+      if (isAssetPath(selectedAssetFile.filePath)) {
+        return {
+          containerClass: classes.autoScroll,
+          content: (
+            <ScenePathRootProvider path={DISCARD_ROOT_PATH}>
+              <AssetConfigurator
+                selectedAsset={selectedAsset}
+              />
+            </ScenePathRootProvider>
+          ),
+        }
+      } else {
+        return {
+          containerClass: classes.neverScroll,
+          content: (
+            <ScenePathRootProvider path={DISCARD_ROOT_PATH}>
+              <FileConfigurator location={selectedAsset} />
+            </ScenePathRootProvider>
+          ),
+        }
+      }
+    } else if (selectedImageTarget) {
+      return {
+        containerClass: classes.neverScroll,
+        content: (
+          <ScenePathRootProvider path={DISCARD_ROOT_PATH}>
+            <ImageTargetAssetConfigurator />
+          </ScenePathRootProvider>
+        ),
+      }
+    } else {
+      return null
+    }
+  }
+
+  const inspector = renderInspector()
+  const canInspect = !!inspector
+
+  React.useEffect(() => {
+    if (!canInspect && currentPanelSection === PanelSelection.INSPECTOR) {
+      stateCtx.update(p => ({...p, currentPanelSection: PanelSelection.SETTINGS}))
+    }
+  }, [canInspect, currentPanelSection])
+
+  return (
+    <div className={classes.editPanel}>
+      {topBar}
+      <FloatingTray
+        id='floating-right-panel'
+        orientation='vertical'
+        fillContainer
+      >
+        <React.Suspense fallback={<Loader size='small' />}>
+          {(currentPanelSection === PanelSelection.INSPECTOR && inspector)
+            ? (
+              <div className={combine(classes.mainContainer, inspector.containerClass)}>
+                {inspector.content}
+              </div>
+            )
+            : (
+              <div className={combine(classes.mainContainer, classes.neverScroll)} />
+            )
+          }
+        </React.Suspense>
+      </FloatingTray>
+    </div>
+  )
+}
+
+export {
+  FloatingRightPanel,
+  RIGHT_PANEL_WIDTH,
+}

--- a/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+import {useTranslation} from 'react-i18next'
+import {useHistory} from 'react-router-dom'
+
+import {useEnclosedApp} from '../apps/enclosed-app-context'
+import {IMAGE_TARGET_SIMULATOR_PANEL_GALLERY_ID} from '../apps/image-targets/image-target-constants'
+
+import {LogContainerSplit} from '../apps/log-container-split'
+import {useAppPathsContext} from '../common/app-container-context'
+import {INLINE_SIMULATOR_SESSION_ID} from '../editor/app-preview/app-preview-constants'
+import {InlineAppPreviewPane} from '../editor/app-preview/inline-app-preview-pane'
+import {
+  deriveEditorRouteParams, EditorFileLocation, editorFileLocationEqual,
+} from '../editor/editor-file-location'
+import {FileActionsContext} from '../editor/files/file-actions-context'
+import {useConsoleActivity} from '../editor/hooks/use-console-activity'
+import {useFileActionsState} from '../editor/hooks/use-file-actions-state'
+import {usePersistentEditorSession} from '../editor/hooks/use-persistent-editor-session'
+import {useSystemLog} from '../editor/hooks/use-system-log'
+import {BuildControlTray} from '../studio/build-control-tray'
+import {DebugSessionsMenu} from '../studio/debug-sessions-menu'
+import {FileBrowser} from '../studio/file-browser'
+import {RIGHT_PANEL_WIDTH} from '../studio/floating-right-panel'
+import {useLocalSyncContext} from '../studio/local-sync-context'
+import {FloatingRightPanel} from './non-studio-right-panel'
+import {PanelSelection, useStudioStateContext} from '../studio/studio-state-context'
+import {FloatingIconButton} from '../ui/components/floating-icon-button'
+import {FloatingTray} from '../ui/components/floating-tray'
+import {SpaceBetween} from '../ui/layout/space-between'
+import {createThemedStyles} from '../ui/theme'
+import {HOME_PATH} from './desktop-paths'
+
+const useStyles = createThemedStyles(theme => ({
+  nonStudioView: {
+    background: theme.nonStudioViewBg,
+    padding: '4px',
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr auto',
+    justifyContent: 'stretch',
+    alignContent: 'stretch',
+    gap: '4px',
+    flexGrow: 1,
+    height: '100%',
+  },
+  leftColumn: {
+    justifySelf: 'stretch',
+    flexGrow: 1,
+    display: 'flex',
+    gap: '4px',
+    flexDirection: 'column',
+    width: `${RIGHT_PANEL_WIDTH}px`,
+    overflow: 'hidden',
+    flexBasis: 0,
+  },
+}))
+
+const NonStudioView: React.FC = () => {
+  const classes = useStyles()
+  useSystemLog()
+  useConsoleActivity()
+  const stateCtx = useStudioStateContext()
+  const {t} = useTranslation('common')
+  const history = useHistory()
+  const app = useEnclosedApp()
+  const debugReady = !!useLocalSyncContext().localBuildUrl
+
+  const {getStudioRoute} = useAppPathsContext()
+
+  const getLocationFromFile = (file: EditorFileLocation) => getStudioRoute(
+    deriveEditorRouteParams(file), {}
+  )
+
+  const editorSession = usePersistentEditorSession(
+    '',
+    getLocationFromFile,
+    ''
+  )
+
+  const handleBeforeFileSelect = (
+    location: EditorFileLocation
+  ) => {
+    if (!editorFileLocationEqual(location, stateCtx.state.selectedAsset)) {
+      stateCtx.update(p => ({
+        ...p,
+        selectedIds: [],
+        selectedAsset: location,
+        selectedImageTarget: undefined,
+        currentPanelSection: PanelSelection.INSPECTOR,
+      }))
+    }
+    return true
+  }
+
+  const {
+    actionsContext, fileActionModals, fileUploadState, uploadDropRef, handleFileUpload,
+  } = useFileActionsState({
+    editorSession,
+    checkProtectedFile: () => false,
+    onBeforeFileSelect: handleBeforeFileSelect,
+  })
+
+  let res = (
+    <>
+      <div className={classes.nonStudioView}>
+        <div className={classes.leftColumn}>
+          <SpaceBetween narrow>
+            <FloatingTray overflowHidden>
+              <FloatingIconButton
+                a8='click;studio;navigation-menu-button'
+                text={t('button.home', {ns: 'common'})}
+                stroke='home'
+                onClick={() => history.push(HOME_PATH)}
+              />
+            </FloatingTray>
+            <BuildControlTray />
+          </SpaceBetween>
+          <FloatingTray fillContainer orientation='vertical'>
+            <FileBrowser
+              uploadDropRef={uploadDropRef}
+              handleFileUpload={handleFileUpload}
+              fileUploadState={fileUploadState}
+              activeFileLocation={null}
+            />
+          </FloatingTray>
+        </div>
+        <FloatingTray fillContainer>
+          <InlineAppPreviewPane
+            app={app}
+            simulatorId={INLINE_SIMULATOR_SESSION_ID}
+            sessionId={INLINE_SIMULATOR_SESSION_ID}
+            isDragging={false}
+            hidePreviewBottom={false}
+            targetsGalleryUuid={IMAGE_TARGET_SIMULATOR_PANEL_GALLERY_ID}
+            showLoadingOverlay={!debugReady}
+            hideCloseButton
+          />
+        </FloatingTray>
+        <FloatingRightPanel topBar={null} />
+      </div>
+      {fileActionModals}
+    </>
+  )
+
+  res = <FileActionsContext.Provider value={actionsContext}>{res}</FileActionsContext.Provider>
+  res = <LogContainerSplit extraTabContent={<DebugSessionsMenu />}>{res}</LogContainerSplit>
+  return res
+}
+
+export {
+  NonStudioView,
+}

--- a/reality/cloud/xrhome/src/client/editor/app-preview/inline-app-preview-pane.tsx
+++ b/reality/cloud/xrhome/src/client/editor/app-preview/inline-app-preview-pane.tsx
@@ -117,6 +117,7 @@ interface IInlineAppPreviewPane {
   showLoadingOverlay?: boolean
   locationDropdownVisible?: boolean
   warningBannerMsg?: React.ReactNode
+  hideCloseButton?: boolean
 }
 
 const HARD_RELOAD_TIMEOUT = MILLISECONDS_PER_SECOND
@@ -140,7 +141,7 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
   app, simulatorId, isDragging, isStandalone, sessionId, onBoundsChange, collapsed, setCollapsed,
   hidePreviewBottom, targetsGalleryUuid,
   imageTargetQuaternion, renderActions, liveSyncMode, showLoadingOverlay, locationDropdownVisible,
-  warningBannerMsg,
+  warningBannerMsg, hideCloseButton,
 }) => {
   const classes = useStyles()
   const appPreviewStyles = useAppPreviewStyles()
@@ -478,7 +479,7 @@ const InlineAppPreviewPane: React.FC<IInlineAppPreviewPane> = ({
                       </Popup>
                     </div>
                     {setCollapsed && renderCollapseButton(previewPaneMeasure.contentRect.bounds)}
-                    {!isStandalone &&
+                    {!isStandalone && !hideCloseButton &&
                       <div className={appPreviewStyles.actionButton}>
                         <IconButton
                           stroke='cancelLarge'

--- a/reality/cloud/xrhome/src/client/ui/theme.tsx
+++ b/reality/cloud/xrhome/src/client/ui/theme.tsx
@@ -106,7 +106,7 @@ type UIThemeTokens =
   'appCardBorder' |'appCardDisabledBorder' | 'appCardShadowColor' | 'appCardBgColor' |
   'tableBorder' | 'tableHeadBg' | 'tableHeadFg' | 'recaptchaTheme' | 'navLogoColor' |
   'footerHeaderColor'| 'appCardCondensedWidth' | 'codeSearchResultBorderRadius' |
-  'codeSearchResultAppCardPadding'
+  'codeSearchResultAppCardPadding' | 'nonStudioViewBg'
 
 type UiTheme = Record<UIThemeTokens, any>
 
@@ -389,6 +389,7 @@ const LightTheme: UiTheme = {
   appCardCondensedWidth: '25em',
   codeSearchResultBorderRadius: '0',
   codeSearchResultAppCardPadding: 'auto',
+  nonStudioViewBg: gray2,
 }
 /* eslint-enable max-len, local-rules/hardcoded-copy */
 
@@ -661,7 +662,7 @@ const DarkTheme: UiTheme = {
   appCardCondensedWidth: '25em',
   codeSearchResultBorderRadius: '0',
   codeSearchResultAppCardPadding: 'auto',
-
+  nonStudioViewBg: gray6,
 }
 /* eslint-enable max-len, local-rules/hardcoded-copy */
 


### PR DESCRIPTION
## Context

Part of https://github.com/8thwall/8thwall/issues/215

## Testing

Without changes to the open project flow, I worked around by adding an empty expanse.json, opening the project, then deleting the file

- Can view files
- Can run a build
- Can import assets
- Can open the simulator, and if dev8 is added, get device logs and simulator playback
- Can import/edit image targets

<img width="1227" height="822" alt="Screenshot 2026-06-05 at 10 57 25 PM" src="https://github.com/user-attachments/assets/825d7765-de10-4e98-a45c-276c537ae466" />

<img width="1235" height="821" alt="Screenshot 2026-06-05 at 10 56 57 PM" src="https://github.com/user-attachments/assets/65b00398-7cc6-4eef-bf77-f87abdb820dd" />

<img width="1231" height="824" alt="Screenshot 2026-06-05 at 10 56 49 PM" src="https://github.com/user-attachments/assets/ffa6a670-ee0f-42b1-b6fe-6e0ac58494c1" />

<img width="1231" height="822" alt="Screenshot 2026-06-05 at 11 01 26 PM" src="https://github.com/user-attachments/assets/525fee8f-1ae4-45c6-8f20-c16bff7c499c" />
