### PR TITLE
[xrhome] Remove new component button for non-studio apps

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
@@ -120,6 +120,7 @@ const NonStudioView: React.FC = () => {
               handleFileUpload={handleFileUpload}
               fileUploadState={fileUploadState}
               activeFileLocation={null}
+              isStudio={false}
             />
           </FloatingTray>
         </div>

--- a/reality/cloud/xrhome/src/client/studio/file-browser-corner-button.tsx
+++ b/reality/cloud/xrhome/src/client/studio/file-browser-corner-button.tsx
@@ -15,11 +15,13 @@ interface IFileBrowserCornerButton {
   disableNewFiles?: boolean
   setExternalAdding: (adding: boolean, isAssetPath?: boolean) => void
   setExternalItemType: (itemType: ItemType) => void
+  supportsNewComponentFile: boolean
 }
 
 const FileBrowserCornerButton: React.FC<IFileBrowserCornerButton> = ({
   onFileSelect, disableNewFiles, onCreateItem,
   setExternalAdding, setExternalItemType,
+  supportsNewComponentFile,
 }) => {
   const {t} = useTranslation(['cloud-editor-pages', 'cloud-studio-pages'])
 
@@ -33,9 +35,10 @@ const FileBrowserCornerButton: React.FC<IFileBrowserCornerButton> = ({
   const fileOptions = useNewFileOptions({
     startNewItem,
     supportsNewFile: !!onCreateItem && !disableNewFiles,
-    supportsNewComponentFile: !!onCreateItem && !disableNewFiles,
+    supportsNewComponentFile: supportsNewComponentFile && !!onCreateItem && !disableNewFiles,
     supportsNewFolder: false,
     supportsAssetBundle: false,
+
   })
 
   const options = [

--- a/reality/cloud/xrhome/src/client/studio/file-browser-list.tsx
+++ b/reality/cloud/xrhome/src/client/studio/file-browser-list.tsx
@@ -71,12 +71,14 @@ interface IFileBrowserList {
   externalItemType?: ItemType
   setExternalItemType?: (itemType: ItemType) => void
   grow?: boolean
+  supportsNewComponentFile?: boolean
 }
 
 const FileBrowserList: React.FC<IFileBrowserList> = ({
   title, subtitle, onFileSelect, paths, currentEditorFileLocation,
   disableNewFiles, onCreateItem, additionalOptions = [], productTourId, onCreateBackendConfig,
   externalAdding, setExternalAdding, externalItemType, setExternalItemType, grow,
+  supportsNewComponentFile = false,
 }) => {
   const {t} = useTranslation(['cloud-editor-pages'])
   const classes = useStyles()
@@ -119,7 +121,7 @@ const FileBrowserList: React.FC<IFileBrowserList> = ({
   const fileOptions = useNewFileOptions({
     startNewItem,
     supportsNewFile: !!onCreateItem && !disableNewFiles,
-    supportsNewComponentFile: !!onCreateItem && !disableNewFiles,
+    supportsNewComponentFile: supportsNewComponentFile && !!onCreateItem && !disableNewFiles,
     supportsNewFolder: !!onCreateItem,
     supportsAssetBundle: false,
   })

--- a/reality/cloud/xrhome/src/client/studio/file-browser.tsx
+++ b/reality/cloud/xrhome/src/client/studio/file-browser.tsx
@@ -106,7 +106,7 @@ interface IFileBrowser {
   handleFileUpload: (event: React.ChangeEvent<HTMLInputElement>) => void
   fileUploadState: UploadState
   activeFileLocation: ScopedFileLocation
-  isStudio?: boolean
+  isStudio: boolean
 }
 
 const FileBrowser: React.FC<IFileBrowser> = ({
@@ -183,6 +183,7 @@ const FileBrowser: React.FC<IFileBrowser> = ({
       }
         <FileBrowserList
           onCreateItem={onCreate}
+          supportsNewComponentFile={isStudio}
           onFileSelect={onUploadStart}
           paths={files.text}
           currentEditorFileLocation={activeFileLocation}
@@ -320,6 +321,7 @@ const FileBrowser: React.FC<IFileBrowser> = ({
             />
           }
           <FileBrowserCornerButton
+            supportsNewComponentFile={isStudio}
             onFileSelect={onUploadStart}
             onCreateItem={onCreate}
             setExternalAdding={handleExternalAdding}


### PR DESCRIPTION
## Context

Part of #215 

## Testing


Non studio just has a new file option

<img width="474" height="199" alt="Screenshot 2026-06-07 at 2 27 21 PM" src="https://github.com/user-attachments/assets/7ce27ac4-a0c2-44e5-9a56-310ff2a8ecfb" />

Studio still has both options

<img width="426" height="172" alt="Screenshot 2026-06-07 at 2 27 47 PM" src="https://github.com/user-attachments/assets/2ce07e7c-472f-40b6-a9a6-d69aac7b4800" />

