### PR TITLE
[xrhome] Display errors in non-studio view

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
@@ -29,6 +29,8 @@ import {FloatingTray} from '../ui/components/floating-tray'
 import {SpaceBetween} from '../ui/layout/space-between'
 import {createThemedStyles} from '../ui/theme'
 import {HOME_PATH} from './desktop-paths'
+import ErrorMessage from '../home/error-message'
+import {StaticBanner} from '../ui/components/banner'
 
 const useStyles = createThemedStyles(theme => ({
   nonStudioView: {
@@ -91,6 +93,10 @@ const NonStudioView: React.FC = () => {
     return true
   }
 
+  React.useEffect(() => {
+    stateCtx.update({errorMsg: 'my error'})
+  }, [])
+
   const {
     actionsContext, fileActionModals, fileUploadState, uploadDropRef, handleFileUpload,
   } = useFileActionsState({
@@ -115,6 +121,15 @@ const NonStudioView: React.FC = () => {
             <BuildControlTray />
           </SpaceBetween>
           <FloatingTray fillContainer orientation='vertical'>
+            {stateCtx.state.errorMsg &&
+              <StaticBanner
+                type='danger'
+                onClose={() => stateCtx.update(p => ({...p, errorMsg: ''}))}
+              >
+                {stateCtx.state.errorMsg}
+              </StaticBanner>
+            }
+            <ErrorMessage />
             <FileBrowser
               uploadDropRef={uploadDropRef}
               handleFileUpload={handleFileUpload}

--- a/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/non-studio-view.tsx
@@ -34,6 +34,11 @@ import {StaticBanner} from '../ui/components/banner'
 
 const useStyles = createThemedStyles(theme => ({
   nonStudioView: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    left: 0,
+    bottom: 0,
     background: theme.nonStudioViewBg,
     padding: '4px',
     display: 'grid',
@@ -41,8 +46,6 @@ const useStyles = createThemedStyles(theme => ({
     justifyContent: 'stretch',
     alignContent: 'stretch',
     gap: '4px',
-    flexGrow: 1,
-    height: '100%',
   },
   leftColumn: {
     justifySelf: 'stretch',
@@ -93,10 +96,6 @@ const NonStudioView: React.FC = () => {
     return true
   }
 
-  React.useEffect(() => {
-    stateCtx.update({errorMsg: 'my error'})
-  }, [])
-
   const {
     actionsContext, fileActionModals, fileUploadState, uploadDropRef, handleFileUpload,
   } = useFileActionsState({
@@ -120,7 +119,7 @@ const NonStudioView: React.FC = () => {
             </FloatingTray>
             <BuildControlTray />
           </SpaceBetween>
-          <FloatingTray fillContainer orientation='vertical'>
+          <FloatingTray fillContainer orientation='vertical' overflowHidden>
             {stateCtx.state.errorMsg &&
               <StaticBanner
                 type='danger'


### PR DESCRIPTION
## Context

Part of #215 

These were missing so if something happened you wouldn't be notified of the error

## Testing

<img width="344" height="384" alt="Screenshot 2026-06-10 at 5 52 29 PM" src="https://github.com/user-attachments/assets/4fa1f4e5-941c-43ea-bb77-3756705ef380" />
