### PR TITLE
[xrhome] Clear query cache on crash

### DIFF
--- a/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Trans, useTranslation} from 'react-i18next'
 import {createUseStyles} from 'react-jss'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {PrimaryButton} from '../ui/components/primary-button'
 import CopyableBlock from '../widgets/copyable-block'
@@ -36,6 +37,11 @@ const CaughtErrorPage: React.FC<ICaughtErrorPage> = ({error, onReset}) => {
   const {t} = useTranslation(['caught-error-page', 'common'])
 
   const classes = useStyles()
+  const queryClient = useQueryClient()
+
+  React.useEffect(() => {
+    queryClient.clear()
+  }, [])
 
   return (
     <div className={classes.caughtErrorPage}>


### PR DESCRIPTION
## Context

This is part of https://github.com/8thwall/8thwall/issues/145 - when a crash occurs, the back button remounts the previous page, but if the crash was due to a failed query, and we don't clear the cache, the same crash occurs again, without refetching, so the issue is unrecoverable.

## Testing

With a placeholder error in `getRuntimeMetadataQuery`

```diff
+++ b/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
@@ -12,8 +12,9 @@ const getRuntimeMetadataQuery = (appKey: string) => ({
     // initialized. After the server starts, it will trigger a refetch regardless, but to avoid
     // error screens on start, absorb failures.
     let iterations = 0
-    while (iterations++ < 10) {
+    while (iterations++ < 2) {
       try {
+        throw new Error('test')
         return await getRuntimeMetadata(appKey)
       } catch (err) {
         await new Promise(r => setTimeout(r, 1500))
```

### Before

- Clicking Back immediately returns to the crash screen

### After

- Clicking Back returns to the screen with the retries reset, so it retries/polls again (then finally errors), but we had a chance to succeed.