### PR TITLE
[desktop] Improve reliability of npm install on windows

### DIFF
--- a/apps/desktop/BUILD
+++ b/apps/desktop/BUILD
@@ -129,3 +129,10 @@ js_library(
         "//apps/desktop:errors",
     ],
 )
+
+js_library(
+    name = "process",
+    srcs = [
+        "process.ts",
+    ],
+)

--- a/apps/desktop/app/file-sync/BUILD
+++ b/apps/desktop/app/file-sync/BUILD
@@ -107,8 +107,10 @@ js_library(
         "run-commands.ts",
     ],
     deps = [
+        "//apps/desktop:process",
         "//apps/desktop/app:resources",
         "//apps/desktop/app/system-log:listeners",
+        "//reality/cloud/xrhome/src/shared:time-utils",
     ],
 )
 

--- a/apps/desktop/app/file-sync/run-commands.ts
+++ b/apps/desktop/app/file-sync/run-commands.ts
@@ -5,7 +5,7 @@ import log from 'electron-log'
 import {MILLISECONDS_PER_MINUTE} from '@repo/reality/cloud/xrhome/src/shared/time-utils'
 
 import {NODE_MODULES_PATH} from '../resources'
-import {dispatchSystemLog, forwardProcessOutput} from '../system-log/listeners'
+import {forwardProcessOutput} from '../system-log/listeners'
 import {parseCommandString, Process, startProcess} from '../../process'
 
 const NPM_CLI_PATH = path.join(NODE_MODULES_PATH, 'npm/bin/npm-cli.js')
@@ -63,11 +63,12 @@ const runScript = (options: ScriptRunOptions): Process => {
     })
   }
 
-  // Otherwise invoke the command through the shell, assuming npm is installed on the PATH.
+  // Otherwise invoke the command through npm. Any dependencies will need to be installed
+  // on the system.
   return startProcess({
-    command: ['npm', 'run', name, '--', ...additionalArgs],
+    command: [EXEC_PATH, NPM_CLI_PATH, 'run', name, '--', ...additionalArgs],
     cwd,
-    env,
+    env: {...env, ELECTRON_RUN_AS_NODE: '1'},
   })
 }
 
@@ -91,7 +92,7 @@ const runInstallCommand = async (
       return
     }
     timeout = setTimeout(() => {
-      log.info('Npm install timeout reached, killing')
+      log.info('NPM install timeout reached, killing process')
       killed = true
       child.kill()
     }, 2 * MILLISECONDS_PER_MINUTE)
@@ -102,12 +103,13 @@ const runInstallCommand = async (
 
   try {
     await child.exitSuccess()
+    log.info('Install complete!')
   } catch (err) {
     log.error('Install failed:', err)
     throw err
+  } finally {
+    clearTimeout(timeout)
   }
-  log.info('Install complete!')
-  clearTimeout(timeout)
 }
 
 const runBuildCommand = async (

--- a/apps/desktop/app/file-sync/run-commands.ts
+++ b/apps/desktop/app/file-sync/run-commands.ts
@@ -1,13 +1,15 @@
-import {ChildProcess, exec, fork} from 'child_process'
 import path from 'path'
 import fs from 'fs'
 import log from 'electron-log'
 
+import {MILLISECONDS_PER_MINUTE} from '@repo/reality/cloud/xrhome/src/shared/time-utils'
+
 import {NODE_MODULES_PATH} from '../resources'
-import {forwardProcessOutput} from '../system-log/listeners'
+import {dispatchSystemLog, forwardProcessOutput} from '../system-log/listeners'
+import {parseCommandString, Process, startProcess} from '../../process'
 
 const NPM_CLI_PATH = path.join(NODE_MODULES_PATH, 'npm/bin/npm-cli.js')
-const EXEC_PATH = process.platform === 'darwin'
+const EXEC_PATH: string = process.platform === 'darwin'
 // @ts-expect-error It exists according to
 // https://github.com/electron/electron/blob/v39.5.1/lib/node/init.ts#L35
   ? process.helperExecPath
@@ -24,7 +26,7 @@ type ScriptRunOptions = {
   arguments?: ('--port' | `${number}`)[]
 }
 
-const runScript = (options: ScriptRunOptions): ChildProcess => {
+const runScript = (options: ScriptRunOptions): Process => {
   const {cwd, name, env} = options
 
   const packageJsonPath = path.resolve(cwd, 'package.json')
@@ -43,138 +45,96 @@ const runScript = (options: ScriptRunOptions): ChildProcess => {
     throw new Error(`npm run ${name} command not found in package.json`)
   }
 
-  // TODO(christoph): Escape these args, currently only allows port and port number
-  const additionalArgs = (options.arguments || []).join(' ')
+  const additionalArgs = (options.arguments || [])
 
   // If command starts with 'node ', fork the electron process so that we can run scripts
   // even if node isn't installed.
   if (scriptCommand.startsWith('node ')) {
-    const command = `"${EXEC_PATH}"${scriptCommand.slice('node'.length)} ${additionalArgs}`
-    log.info(`Running command: ${name} - ${command}`)
-    return exec(
+    const command = [
+      EXEC_PATH,
+      ...parseCommandString(scriptCommand.slice('node'.length)),
+      ...additionalArgs,
+    ]
+    log.info(`Running command: ${name} - ${command.join(' ')}`)
+    return startProcess({
       command,
-      {cwd, env: {...env, ELECTRON_RUN_AS_NODE: '1'}}
-    )
+      cwd,
+      env: {...env, ELECTRON_RUN_AS_NODE: '1'},
+    })
   }
 
   // Otherwise invoke the command through the shell, assuming npm is installed on the PATH.
-  return exec(
-    `npm run ${name} -- ${additionalArgs}`,
-    {cwd, env, shell: process.env.SHELL}
-  )
+  return startProcess({
+    command: ['npm', 'run', name, '--', ...additionalArgs],
+    cwd,
+    env,
+  })
 }
 
 const runInstallCommand = async (
   appKey: string, savePath: string, extraArguments?: string[]
-): Promise<void> => new Promise((resolve, reject) => {
-  const child = fork(
-    NPM_CLI_PATH,
-    ['install', ...(extraArguments || [])],
-    {cwd: savePath, stdio: 'pipe', env: {...COMMON_ENV, ELECTRON_RUN_AS_NODE: '1'}, detached: true}
-  )
+): Promise<void> => {
+  log.info('Running install command')
 
-  forwardProcessOutput(appKey, child)
-
-  const timeout = setTimeout(() => {
-    log.error('npm install timed out, killing process')
-    child.kill('SIGTERM')
-    reject(new Error('npm install timed out'))
-  }, 60000)
-
-  let stderr = ''
-
-  child.stderr?.on('data', (d) => {
-    const out = d.toString()
-    stderr += out
+  const child = startProcess({
+    command: [EXEC_PATH, NPM_CLI_PATH, 'install', ...(extraArguments || [])],
+    cwd: savePath,
+    env: {...COMMON_ENV, ELECTRON_RUN_AS_NODE: '1'},
   })
+  log.info('Install started')
+  dispatchSystemLog({appKey, 'type': 'log', 'text': 'Installing packages'})
 
-  child.on('exit', (code, signal) => {
+  forwardProcessOutput(appKey, child.nodeChildProcess)
+
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let killed = false
+  const restartTimeout = () => {
     clearTimeout(timeout)
-    if (code === 0) {
-      resolve()
-    } else {
-      const msg = `npm install failed (exit ${code}, signal ${signal})\nstderr:\n${stderr}`
-      log.error(msg)
-      reject(new Error(msg))
+    if (killed) {
+      return
     }
-  })
+    timeout = setTimeout(() => {
+      log.info('Timeout reached')
+      killed = true
+      child.kill()
+    }, 2 * MILLISECONDS_PER_MINUTE)
+  }
+  restartTimeout()
+  child.nodeChildProcess.stdout?.on('data', () => restartTimeout())
+  child.nodeChildProcess.stderr?.on('data', () => restartTimeout())
 
-  child.on('error', (err) => {
-    clearTimeout(timeout)
-    log.error('npm install process error:', err)
-    if (stderr) {
-      log.error('npm install stderr:', stderr)
-    }
-    reject(err)
-  })
-})
+  try {
+    await child.exitSuccess()
+  } catch (err) {
+    log.error('Install failed', err)
+    throw err
+  }
+  log.info('Install complete!')
 
-const runBuildCommand = (
+  clearTimeout(timeout)
+}
+
+const runBuildCommand = async (
   appKey: string,
   savePath: string
-): Promise<void> => new Promise((resolve, reject) => {
+): Promise<void> => {
   const child = runScript({
     cwd: savePath,
     name: 'build',
     env: COMMON_ENV,
   })
 
-  forwardProcessOutput(appKey, child)
+  forwardProcessOutput(appKey, child.nodeChildProcess)
 
-  child.on('exit', (code, signal) => {
-    if (signal === 'SIGTERM' || signal === 'SIGKILL') {
-      return
-    }
-    if (code === 0) {
-      resolve()
-    } else {
-      const msg = 'webpack build failed'
-      log.error(msg)
-      reject(new Error(msg))
-    }
-  })
-
-  child.on('error', (err) => {
-    log.error('webpack build process error:', err)
-    reject(err)
-  })
-})
-
-const runServeCommand = (savePath: string, port: number): ChildProcess => {
-  const child = runScript({
-    cwd: savePath,
-    name: 'serve',
-    env: {...COMMON_ENV, PORT: port.toString()},
-    arguments: ['--port', `${port}`],
-  })
-
-  let stderr = ''
-
-  child.stderr?.on('data', (d) => {
-    const out = d.toString()
-    stderr += out
-  })
-
-  child.on('exit', (code, signal) => {
-    if (signal === 'SIGTERM' || signal === 'SIGKILL') {
-      return
-    }
-    if (code !== 0) {
-      const msg = `webpack failed (exit ${code}, signal ${signal})\nstderr:\n${stderr}`
-      log.error(msg)
-    }
-  })
-
-  child.on('error', (err) => {
-    log.error('webpack process error:', err)
-    if (stderr) {
-      log.error('webpack stderr:', stderr)
-    }
-    throw err
-  })
-
-  return child
+  await child.exitSuccess()
 }
+
+const runServeCommand = (savePath: string, port: number): Process => runScript({
+  cwd: savePath,
+  name: 'serve',
+  env: {...COMMON_ENV, PORT: port.toString()},
+  arguments: ['--port', `${port}`],
+})
 
 export {
   runServeCommand,

--- a/apps/desktop/app/file-sync/run-commands.ts
+++ b/apps/desktop/app/file-sync/run-commands.ts
@@ -74,16 +74,13 @@ const runScript = (options: ScriptRunOptions): Process => {
 const runInstallCommand = async (
   appKey: string, savePath: string, extraArguments?: string[]
 ): Promise<void> => {
-  log.info('Running install command')
-
+  log.info('Running install command', savePath, extraArguments)
   const child = startProcess({
     command: [EXEC_PATH, NPM_CLI_PATH, 'install', ...(extraArguments || [])],
     cwd: savePath,
     env: {...COMMON_ENV, ELECTRON_RUN_AS_NODE: '1'},
   })
   log.info('Install started')
-  dispatchSystemLog({appKey, 'type': 'log', 'text': 'Installing packages'})
-
   forwardProcessOutput(appKey, child.nodeChildProcess)
 
   let timeout: ReturnType<typeof setTimeout> | undefined
@@ -94,7 +91,7 @@ const runInstallCommand = async (
       return
     }
     timeout = setTimeout(() => {
-      log.info('Timeout reached')
+      log.info('Npm install timeout reached, killing')
       killed = true
       child.kill()
     }, 2 * MILLISECONDS_PER_MINUTE)
@@ -106,11 +103,10 @@ const runInstallCommand = async (
   try {
     await child.exitSuccess()
   } catch (err) {
-    log.error('Install failed', err)
+    log.error('Install failed:', err)
     throw err
   }
   log.info('Install complete!')
-
   clearTimeout(timeout)
 }
 

--- a/apps/desktop/local-server.ts
+++ b/apps/desktop/local-server.ts
@@ -1,5 +1,4 @@
 import {fetch, Agent} from 'undici'
-import {exec, ChildProcess} from 'child_process'
 import getPort, {portNumbers, clearLockedPorts} from 'get-port'
 
 import {guessIp} from '@repo/c8/cli/ip'
@@ -8,7 +7,7 @@ import {
   DEV_SERVER_POLLING_INTERVAL, DEV_SERVER_POLLING_TIMEOUT,
 } from './constants'
 import {runServeCommand, runInstallCommand} from './app/file-sync/run-commands'
-import {forwardProcessOutput} from './app/system-log/listeners'
+import {dispatchSystemLog, forwardProcessOutput} from './app/system-log/listeners'
 import {startLocalProxy} from './app/file-sync/local-proxy'
 import {createDev8WebSocketServer} from './app/dev8-socket/dev8-socket-server'
 
@@ -20,43 +19,13 @@ interface LocalServer {
   getLocalBuildRemoteUrl: () => Promise<string>
 }
 
-const IS_WINDOWS = process.platform === 'win32'
-
 const LOCAL_BUILD_URL_BASE = 'http://localhost:'
-
-const isProcessRunning = (process: ChildProcess | undefined): process is ChildProcess => (
-  !!process && !process.killed && process.exitCode === null
-)
-
-const killProcess = async (process: ChildProcess | undefined): Promise<void> => {
-  if (!isProcessRunning(process)) {
-    return
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    if (IS_WINDOWS) {
-      exec(`taskkill /pid ${process.pid} /T /F`, err => (err ? reject(err) : resolve()))
-      return
-    }
-    process.on('exit', () => {
-      resolve()
-    })
-
-    process.kill('SIGTERM')
-
-    // Fallback: force kill after 5 seconds if SIGTERM doesn't work
-    setTimeout(() => {
-      if (process && !process.killed) {
-        process.kill('SIGKILL')
-      }
-    }, 5000)
-  })
-}
 
 const createLocalServer = async (
   appKey: string,
   savePath: string
 ): Promise<LocalServer> => {
+  dispatchSystemLog({appKey, 'type': 'log', 'text': 'Installing packages'})
   await runInstallCommand(appKey, savePath)
   const [primaryPort, buildPort, dev8SocketPort] = await Promise.all([
     getPort({port: portNumbers(58000, 58999)}),
@@ -66,7 +35,7 @@ const createLocalServer = async (
 
   const webpackDevServer = runServeCommand(savePath, buildPort)
   const dev8Socket = createDev8WebSocketServer(appKey, dev8SocketPort)
-  forwardProcessOutput(appKey, webpackDevServer)
+  forwardProcessOutput(appKey, webpackDevServer.nodeChildProcess)
   const proxy = startLocalProxy({primaryPort, buildPort, dev8SocketPort})
 
   const localServerCheck = async () => {
@@ -87,7 +56,7 @@ const createLocalServer = async (
     const end = performance.now() + DEV_SERVER_POLLING_TIMEOUT
     /* eslint-disable no-await-in-loop */
     while (performance.now() < end) {
-      if (!isProcessRunning(webpackDevServer)) {
+      if (!webpackDevServer.isRunning()) {
         return false
       }
       if (await localServerCheck()) {
@@ -102,7 +71,7 @@ const createLocalServer = async (
     proxy.stop()
     dev8Socket.close()
     if (webpackDevServer) {
-      await killProcess(webpackDevServer)
+      await webpackDevServer.kill()
     }
     clearLockedPorts()
   }

--- a/apps/desktop/local-server.ts
+++ b/apps/desktop/local-server.ts
@@ -25,14 +25,14 @@ const createLocalServer = async (
   appKey: string,
   savePath: string
 ): Promise<LocalServer> => {
-  dispatchSystemLog({appKey, 'type': 'log', 'text': 'Installing packages'})
+  dispatchSystemLog({appKey, type: 'log', text: 'Installing packages'})
   await runInstallCommand(appKey, savePath)
   const [primaryPort, buildPort, dev8SocketPort] = await Promise.all([
     getPort({port: portNumbers(58000, 58999)}),
     getPort({port: portNumbers(59000, 59999)}),
     getPort({port: portNumbers(60000, 60999)}),
   ])
-
+  dispatchSystemLog({appKey, type: 'log', text: 'Starting build server'})
   const webpackDevServer = runServeCommand(savePath, buildPort)
   const dev8Socket = createDev8WebSocketServer(appKey, dev8SocketPort)
   forwardProcessOutput(appKey, webpackDevServer.nodeChildProcess)

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -15,6 +15,7 @@
         "electron-log": "^5.4.2",
         "electron-squirrel-startup": "^1.0.1",
         "electron-updater": "^6.6.2",
+        "execa": "^10.0.0",
         "get-port": "^7.1.0",
         "handlebars": "^4.7.8",
         "httpxy": "^0.5.1",
@@ -1336,6 +1337,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -1346,6 +1353,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -3703,6 +3722,85 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/execa": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-10.0.0.tgz",
+      "integrity": "sha512-Cxl6MKxB1dr1H0FHmiizJ+lavKF7pV+fcDZFyqMB8d5m7qUPm/OtZYcD5vPWePKxSnTQ57KuBd9mtdZ3oNCvyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.1",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "path-key": "^4.0.0",
+        "pretty-ms": "^9.3.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "which-command": "^0.1.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -3794,6 +3892,33 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -4337,6 +4462,15 @@
       "integrity": "sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A==",
       "license": "MIT"
     },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -4502,6 +4636,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -5308,6 +5454,34 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
@@ -7747,6 +7921,18 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/patch-package": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
@@ -8067,6 +8253,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/proc-log": {
@@ -8813,6 +9014,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -9223,6 +9436,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
@@ -9326,6 +9551,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-command": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/which-command/-/which-command-0.1.0.tgz",
+      "integrity": "sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==",
+      "license": "MIT",
+      "bin": {
+        "which-command": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/which-command?sponsor=1"
       }
     },
     "node_modules/wordwrap": {
@@ -9472,6 +9712,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,7 @@
     "electron-log": "^5.4.2",
     "electron-squirrel-startup": "^1.0.1",
     "electron-updater": "^6.6.2",
+    "execa": "^10.0.0",
     "get-port": "^7.1.0",
     "handlebars": "^4.7.8",
     "httpxy": "^0.5.1",

--- a/apps/desktop/process.ts
+++ b/apps/desktop/process.ts
@@ -1,0 +1,78 @@
+import type ChildProcess from 'child_process'
+import {execa, parseCommandString} from 'execa'
+
+type ProcessOptions = {
+  command: string[]
+  env?: Record<string, string>
+  cwd: string
+}
+
+const IS_WINDOWS = process.platform === 'win32'
+
+type Process = {
+  kill: () => Promise<void>
+  exitSuccess: () => Promise<void>
+  isRunning: () => boolean
+  nodeChildProcess: ChildProcess.ChildProcess
+}
+
+const isProcessRunning = (
+  process: ChildProcess.ChildProcess | undefined
+): process is ChildProcess.ChildProcess => (
+  !!process && !process.killed && process.exitCode === null
+)
+
+const killProcess = async (process: ChildProcess.ChildProcess | undefined): Promise<void> => {
+  if (!isProcessRunning(process)) {
+    return
+  }
+
+  if (IS_WINDOWS) {
+    await execa('taskkill', ['/pid', String(process.pid), '/T', '/F'])
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    process.on('exit', () => {
+      resolve()
+    })
+
+    process.kill('SIGTERM')
+
+    // Fallback: force kill after 5 seconds if SIGTERM doesn't work
+    setTimeout(() => {
+      if (process && !process.killed) {
+        process.kill('SIGKILL')
+      }
+    }, 5000)
+  })
+}
+
+const startProcess = (options: ProcessOptions): Process => {
+  const child = execa(
+    options.command[0],
+    options.command.slice(1),
+    {
+      cwd: options.cwd,
+      env: options.env,
+    }
+  )
+  return {
+    isRunning: () => isProcessRunning(child.nodeChildProcess),
+    kill: () => killProcess(child.nodeChildProcess),
+    nodeChildProcess: child.nodeChildProcess,
+    exitSuccess: async () => {
+      await child
+    },
+  }
+}
+
+export {
+  parseCommandString,
+  startProcess,
+}
+
+export type {
+  ProcessOptions,
+  Process,
+}


### PR DESCRIPTION
## Context

Hopefully improves #145 

This should be a more reliable way to instantiate processes - two possible issues were argument quoting, and environment inheritance.

## Testing

1. Installing packages
2. Build server
3. Build server with custom script, e.g. `"serve": "echo 'starting' && webpack..."`
4. Production build
5. Production build with custom script, e.g. `"build": "echo 'hello build' && mkdir dist && echo hello > index.html"`)

Looks good on mac and windows, with default and custom build/serve commands
