### PR TITLE
[coaching-overlay] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If any questions come up, please refer to our [documentation](https://8th.io/doc
 - [ecs](./packages/ecs/README.md) - The game engine behind 8th Wall Studio
 - [xrextras](./packages/xrextras/README.md) - Helper code for XR and 3D needs
 - [landing-page](./packages/landing-page/README.md) - Fallback experience for unsupported devices
+- [coaching-overlay](./packages/coaching-overlay/README.md) - User guides for Absolute Scale and Sky Effects projects
 
 ### More coming soon!
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If any questions come up, please refer to our [documentation](https://8th.io/doc
 - [ecs](./packages/ecs/README.md) - The game engine behind 8th Wall Studio
 - [xrextras](./packages/xrextras/README.md) - Helper code for XR and 3D needs
 - [landing-page](./packages/landing-page/README.md) - Fallback experience for unsupported devices
-- [coaching-overlay](./packages/coaching-overlay/README.md) - User guides for Absolute Scale and Sky Effects projects
+- [coaching-overlay](./packages/coaching-overlay/README.md) - Helpful user prompts for Absolute Scale and Sky Effects projects
 
 ### More coming soon!
 

--- a/packages/coaching-overlay/README.md
+++ b/packages/coaching-overlay/README.md
@@ -1,0 +1,58 @@
+# Coaching Overlay
+
+Helpful user prompts for Absolute Scale and Sky Effects projects
+
+![Preview of the absolute scale showing a splash image and QR code](https://raw.githubusercontent.com/8thwall/8thwall.github.io/refs/heads/main/static/images/coachingoverlay-example.jpg)
+
+## Usage
+
+See https://8thwall.org/docs/engine/guides/coaching-overlays for a complete guide to customizing the coaching overlay.
+
+### Option 1: Script tag
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@8thwall/coaching-overlay@1/dist/coaching-overlay.js" crossorigin="anonymous"></script>
+```
+  
+### Option 2: npm
+
+```bash
+npm install @8thwall/coaching-overlay
+```
+
+You will need to copy the included artifacts into your dist folder, for example in webpack:
+
+```js
+new CopyWebpackPlugin({
+  patterns: [
+    {
+      from: 'node_modules/@8thwall/coaching-overlay/dist',
+      to: 'external/coaching-overlay',
+    }
+  ]
+})
+```
+
+You can then load the library by adding the following to index.html:
+
+```html
+<script src="./external/coaching-overlay/coaching-overlay.js"></script>
+```
+
+When you import the package, a simple helper for accessing window.CoachingOverlay/window.SkyCoachingOverlay is provided. The expectation is still that the script tag is added to the HTML. Note that configuring the overlays in this way is not required for A-Frame projects as the configuration is passed through the component schema.
+
+```js
+import * as CoachingOverlay from '@8thwall/coaching-overlay'
+CoachingOverlay.AbsoluteScale.configure({
+  promptColor: '#00ff00',
+})
+CoachingOverlay.Sky.configure({
+  promptText: 'Look at the sky!',
+})
+```
+
+## Development
+
+- Start a local server with `npm run watch`
+- Try out the test at `https://localhost:9003/test/`. 
+- In order to use your local version in a project, replace the existing script tag with `<script crossorigin="anonymous" src="https://localhost:9003/coaching-overlay.js"></script>`

--- a/packages/coaching-overlay/RELEASING.md
+++ b/packages/coaching-overlay/RELEASING.md
@@ -1,0 +1,16 @@
+# Releasing
+
+## Publishing a pre-release build
+
+1. Update the package.json to contain a version like "1.x.x-alpha.3"
+
+```
+npm publish --tag alpha --access public --pack-destination tmp
+```
+
+## Publishing a production build
+
+1. Update the package.json version to indicate the changes made since last release, following Semver.
+2. Run: `npm publish --tag latest --access public --pack-destination tmp --dry-run`
+3. If everything looks good, run the command again without `--dry-run`
+


### PR DESCRIPTION
## Context

Part of https://github.com/8thwall/8thwall/issues/89

## Testing

Published to

- https://www.npmjs.com/package/@8thwall/coaching-overlay/v/1.0.0-alpha1 
- https://cdn.jsdelivr.net/npm/@8thwall/coaching-overlay@1.0.0-alpha1/dist/coaching-overlay.js

<img width="1055" height="882" alt="Screenshot 2026-07-31 at 11 58 42 AM" src="https://github.com/user-attachments/assets/128eec8f-be09-4e81-9aab-2960dbe18a58" />
