### PR TITLE
[ecs][xrhome] Add multiline string directive

### DIFF
--- a/c8/ecs/src/shared/parse-component-ast-test.ts
+++ b/c8/ecs/src/shared/parse-component-ast-test.ts
@@ -260,6 +260,36 @@ describe('Cloud Studio - Parse Component Ast', () => {
           },
         }])
     })
+    it('Should support multinline', () => {
+      const content = `ecs.registerComponent({
+        name: 'example',
+        schema: {
+          // @multiline
+          longText: ecs.string,
+        },
+      })\n`
+      assert.deepEqual(parseComponentAst(content).componentData,
+        [{
+          name: 'example',
+          schema: {longText: 'string'},
+          schemaDefaults: undefined,
+          schemaPresentation: {
+            fields: {
+              longText: {
+                mode: 'multiline',
+              },
+            },
+            groups: {},
+            sections: {},
+          },
+          location: {
+            startLine: 1,
+            startColumn: 4,
+            endLine: 1,
+            endColumn: 21,
+          },
+        }])
+    })
     it('Should return enum values and labels', () => {
       const content = `ecs.registerComponent({
         name: 'example',

--- a/c8/ecs/src/shared/parse-component-ast-test.ts
+++ b/c8/ecs/src/shared/parse-component-ast-test.ts
@@ -260,7 +260,7 @@ describe('Cloud Studio - Parse Component Ast', () => {
           },
         }])
     })
-    it('Should support multinline', () => {
+    it('Should support multiline', () => {
       const content = `ecs.registerComponent({
         name: 'example',
         schema: {

--- a/c8/ecs/src/shared/parse-component-ast.ts
+++ b/c8/ecs/src/shared/parse-component-ast.ts
@@ -541,6 +541,24 @@ const extractPresentationElement = (identifier: string, comment: Comment, ctx: P
       }
       break
     }
+    case '@multiline': {
+      const presentation = makeOrGetFieldPresentation(identifier, ctx)
+      if (ctx.schema[identifier] !== 'string') {
+        ctx.warnings.push(createComponentError(
+          `@multiline is only valid for string fields, cannot apply to ${ctx.schema[identifier]}`,
+          'warning', comment
+        ))
+      } else if (presentation.mode) {
+        warnModeAlreadySet(identifier, comment, directiveType, 'multiline', ctx)
+      } else if (directiveContent) {
+        ctx.warnings.push(createComponentError(
+          'There should be no content after @multiline', 'warning', comment
+        ))
+      } else {
+        presentation.mode = 'multiline'
+      }
+      break
+    }
     case '@required': {
       if (ctx.schema[identifier] === 'eid') {
         const presentation = makeOrGetFieldPresentation(identifier, ctx)

--- a/c8/ecs/src/shared/schema.ts
+++ b/c8/ecs/src/shared/schema.ts
@@ -31,7 +31,7 @@ interface SchemaDefaults {
 
 type AssetKind = typeof ASSET_KINDS[number]
 
-type FieldPresentationMode = 'enum' | 'attribute' | 'property' | 'asset' | 'color'
+type FieldPresentationMode = 'enum' | 'attribute' | 'property' | 'asset' | 'color' | 'multiline'
 type AttributeTypeName = typeof ALL_ATTRIBUTE_TYPES[number]
 type GroupType = typeof GROUP_TYPES[number]
 

--- a/reality/cloud/xrhome/src/client/studio/configuration/schema-configurator.tsx
+++ b/reality/cloud/xrhome/src/client/studio/configuration/schema-configurator.tsx
@@ -29,6 +29,8 @@ import {SubMenuSelectWithSearch} from '../ui/submenu-select-with-search'
 import {useSelectedObjects} from '../hooks/selected-objects'
 import {TextNotification} from '../../ui/components/text-notification'
 import {useDerivedScene} from '../derived-scene-context'
+import {StandardTextAreaField} from '../../ui/components/standard-text-area-field'
+import {RowFieldLabel} from './row-field-label'
 
 const useStyles = createUseStyles({
   selectContainer: {
@@ -120,6 +122,23 @@ const StringColorField: React.FC<FieldProps<string>> = ({label, value, onChange}
       value={String(value)}
       label={label}
     />
+  )
+}
+
+const MultilineStringField: React.FC<FieldProps<string>> = ({label, value, onChange}) => {
+  const rowClasses = useRowStyles()
+
+  return (
+    <div className={rowClasses.row}>
+      <StandardTextAreaField
+        label={<RowFieldLabel label={label} expanseField={undefined} />}
+        value={String(value)}
+        onChange={(e) => {
+          onChange(e.target.value)
+        }}
+        rows={3}
+      />
+    </div>
   )
 }
 
@@ -325,6 +344,14 @@ const Field: React.FC<IField> = ({label, type, value, defaultValue, presentation
       } else if (presentation?.mode === 'color') {
         return (
           <StringColorField
+            label={label}
+            value={value ?? defaultValue ?? ''}
+            onChange={onChange}
+          />
+        )
+      } else if (presentation?.mode === 'multiline') {
+        return (
+          <MultilineStringField
             label={label}
             value={value ?? defaultValue ?? ''}
             onChange={onChange}


### PR DESCRIPTION
## Context

Closes https://github.com/8thwall/8thwall/issues/236

## Testing

- Test cases pass (ecs and xrhome)

```
import * as ecs from '@8thwall/ecs'

ecs.registerComponent({
  name: 'example-component',
  schema: {
    data: ecs.string,
    // @multiline
    multiLineData: ecs.string,
  },
  add: (world, component) => {
    console.log('Component attached.', JSON.stringify(component.schema))
  },
})

```

<img width="316" height="186" alt="Screenshot 2026-08-07 at 2 35 11 PM" src="https://github.com/user-attachments/assets/f875d35e-8c0f-4ad6-b492-88e2076117b5" />

```
Component attached. {"data":"this is my text, no newlines","multiLineData":"this is my text\nwith newlines"}
```

