### PR TITLE
[xrhome] Fix prefab renaming in standalone editor

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/readonly-scene-edit-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/readonly-scene-edit-context.tsx
@@ -40,8 +40,6 @@ const ReadonlySceneEditContext: React.FC<IReadonlySceneEditContext> = ({
       isDraggingGizmoRef: {current: false},
       isDraggingGizmo: false,
       setIsDraggingGizmo: noop,
-      isRenamingById: {},
-      setIsRenaming: noop,
       canUndo: false,
       undo: noop,
       canRedo: false,

--- a/reality/cloud/xrhome/src/client/studio/scene-context.ts
+++ b/reality/cloud/xrhome/src/client/studio/scene-context.ts
@@ -9,7 +9,6 @@ interface RawSceneContext {
   scene: SceneGraph
   updateScene: (cb: MutateCallback<SceneGraph>) => void
   updateObject: (id: string, cb: MutateCallback<GraphObject>) => void
-  isRenamingById: Record<string, boolean>
   setIsRenaming: (id: string, isRenaming: boolean) => void
   isDraggingGizmoRef: DeepReadonly<{current: boolean}>
   isDraggingGizmo: boolean

--- a/reality/cloud/xrhome/src/client/studio/scene-context.ts
+++ b/reality/cloud/xrhome/src/client/studio/scene-context.ts
@@ -9,7 +9,6 @@ interface RawSceneContext {
   scene: SceneGraph
   updateScene: (cb: MutateCallback<SceneGraph>) => void
   updateObject: (id: string, cb: MutateCallback<GraphObject>) => void
-  setIsRenaming: (id: string, isRenaming: boolean) => void
   isDraggingGizmoRef: DeepReadonly<{current: boolean}>
   isDraggingGizmo: boolean
   setIsDraggingGizmo: (isDragging: boolean) => void

--- a/reality/cloud/xrhome/src/client/studio/scene-debug-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/scene-debug-context.tsx
@@ -28,13 +28,8 @@ const SceneDebugContext: React.FC<ISceneDebugContext> = ({
   const isDraggingGizmoRef = React.useRef(false)
   const [isDraggingGizmo, setIsDraggingGizmoState] = React.useState(false)
   const undoStack = useUndoStack<DeepReadonly<SceneGraph>>()
-  const [isRenamingById, setIsRenamingById] = React.useState<Record<string, boolean>>({})
 
   const {updateSimulatorState} = useSimulator()
-
-  const setIsRenaming = (id: string, isRenaming: boolean) => {
-    setIsRenamingById(old => ({...old, [id]: isRenaming}))
-  }
 
   const activeCamera = expanseState.scene?.objects?.[expanseState.scene?.activeCamera]
   const activeCameraConfig = activeCamera?.camera?.xr
@@ -78,8 +73,6 @@ const SceneDebugContext: React.FC<ISceneDebugContext> = ({
       isDraggingGizmoRef,
       isDraggingGizmo,
       setIsDraggingGizmo,
-      isRenamingById,
-      setIsRenaming,
       canUndo: undoStack.canUndo,
       undo: () => {
         const oldScene = undoStack.undo(expanseState.scene)
@@ -97,7 +90,7 @@ const SceneDebugContext: React.FC<ISceneDebugContext> = ({
     } as const
   }, [
     expanseState.scene, isDraggingGizmo,
-    undoStack.canRedo, undoStack.canUndo, isRenamingById,
+    undoStack.canRedo, undoStack.canUndo,
   ])
 
   if (!expanseState.ready) {

--- a/reality/cloud/xrhome/src/client/studio/scene-edit.tsx
+++ b/reality/cloud/xrhome/src/client/studio/scene-edit.tsx
@@ -422,7 +422,6 @@ const SceneEdit: React.FC<ISceneEdit> = ({
                         <TreeElementMenuOptions
                           id={selectedIds.at(-1)!}
                           collapse={collapse}
-                          excludeRename
                         />
                       )}
                       <CanvasMenuOptions collapse={collapse} />

--- a/reality/cloud/xrhome/src/client/studio/scene-edit.tsx
+++ b/reality/cloud/xrhome/src/client/studio/scene-edit.tsx
@@ -419,7 +419,11 @@ const SceneEdit: React.FC<ISceneEdit> = ({
                   options={collapse => (
                     <>
                       {selectedIds.length > 0 && (
-                        <TreeElementMenuOptions id={selectedIds.at(-1)!} collapse={collapse} />
+                        <TreeElementMenuOptions
+                          id={selectedIds.at(-1)!}
+                          collapse={collapse}
+                          excludeRename
+                        />
                       )}
                       <CanvasMenuOptions collapse={collapse} />
                     </>

--- a/reality/cloud/xrhome/src/client/studio/tree-element-menu-options.tsx
+++ b/reality/cloud/xrhome/src/client/studio/tree-element-menu-options.tsx
@@ -25,11 +25,11 @@ import {useActiveRoot} from '../hooks/use-active-root'
 interface ITreeElementMenuOptions {
   id: string
   collapse: () => void
-  excludeRename?: boolean
+  onRename?: () => void
 }
 
 const TreeElementMenuOptions: React.FC<ITreeElementMenuOptions> = ({
-  id, collapse, excludeRename = false,
+  id, collapse, onRename,
 }) => {
   const {t} = useTranslation(['cloud-studio-pages', 'common'])
 
@@ -89,9 +89,9 @@ const TreeElementMenuOptions: React.FC<ITreeElementMenuOptions> = ({
       content: t('tree_element_context_menu.button.new_object'),
       options: newObjectOptions,
     },
-    !excludeRename && {
+    onRename && {
       content: t('tree_element_context_menu.button.rename'),
-      onClick: () => ctx.setIsRenaming(id, true),
+      onClick: onRename,
     },
     canDuplicate && {
       content: t('tree_element_context_menu.button.duplicate'),

--- a/reality/cloud/xrhome/src/client/studio/tree-element.tsx
+++ b/reality/cloud/xrhome/src/client/studio/tree-element.tsx
@@ -54,6 +54,7 @@ const TreeElement: React.FC<ITreeElement> = ({
   const selectedRef = React.useRef<HTMLDivElement>(null)
 
   const [newName, setNewName] = React.useState('')
+  const [renaming, setRenaming] = React.useState(false)
 
   const ctx = useSceneContext()
   const stateCtx = useStudioStateContext()
@@ -75,11 +76,11 @@ const TreeElement: React.FC<ITreeElement> = ({
   }, [selection.isSelected])
 
   const cancelRename = () => {
-    ctx.setIsRenaming(id, false)
+    setRenaming(false)
   }
 
   const handleRenameSubmit = () => {
-    ctx.setIsRenaming(id, false)
+    setRenaming(false)
     if (isPrefab(object) && prefabNameExists(derivedScene, newName)) {
       return
     }
@@ -167,7 +168,7 @@ const TreeElement: React.FC<ITreeElement> = ({
                 </div>
               }
             </div>
-            {ctx.isRenamingById[id]
+            {renaming
               ? (
                 <IgnoreKeys>
                   <InlineTextInput
@@ -222,7 +223,13 @@ const TreeElement: React.FC<ITreeElement> = ({
       </div>
       <ContextMenu
         menuState={menuState}
-        options={collapse => <TreeElementMenuOptions id={id} collapse={collapse} />}
+        options={collapse => (
+          <TreeElementMenuOptions
+            id={id}
+            collapse={collapse}
+            onRename={() => setRenaming(true)}
+          />
+        )}
       />
     </div>
   )

--- a/reality/cloud/xrhome/src/client/studio/tree-element.tsx
+++ b/reality/cloud/xrhome/src/client/studio/tree-element.tsx
@@ -227,7 +227,10 @@ const TreeElement: React.FC<ITreeElement> = ({
           <TreeElementMenuOptions
             id={id}
             collapse={collapse}
-            onRename={() => setRenaming(true)}
+            onRename={() => {
+              setNewName(object.name || '')
+              setRenaming(true)
+            }}
           />
         )}
       />

--- a/reality/cloud/xrhome/test/nae-utils-test.ts
+++ b/reality/cloud/xrhome/test/nae-utils-test.ts
@@ -7,7 +7,6 @@ const DEFAULT_SCENE_CTX: SceneContext = {
   updateScene: () => {},
   updateObject: () => {},
   isDraggingGizmo: false,
-  setIsRenaming: () => {},
   isDraggingGizmoRef: {current: false},
   setIsDraggingGizmo: () => {},
   canUndo: false,

--- a/reality/cloud/xrhome/test/nae-utils-test.ts
+++ b/reality/cloud/xrhome/test/nae-utils-test.ts
@@ -7,7 +7,6 @@ const DEFAULT_SCENE_CTX: SceneContext = {
   updateScene: () => {},
   updateObject: () => {},
   isDraggingGizmo: false,
-  isRenamingById: {},
   setIsRenaming: () => {},
   isDraggingGizmoRef: {current: false},
   setIsDraggingGizmo: () => {},


### PR DESCRIPTION
## Context

Closes https://github.com/8thwall/8thwall/issues/191

This bug was due to having two TreeElements of the same object visible on screen at the same time:


<img width="317" height="603" alt="Screenshot 2026-08-07 at 3 54 04 PM" src="https://github.com/user-attachments/assets/a953297d-f1ea-486c-9bf5-2cdec2cb23bb" />

The state of which is selected was global, and since only one of the inputs could be focused, the other one always blurred and triggered the reset of the renaming state.

The reason the state is global is that we had the scene-level context menu which included it. This would normally be a pretty good reason to make the state global, but we can't even guarantee the tree element is visible in the sidebar, so if it's in a parent which is collapsed, it also wouldn't do anything. You can rename from the right panel too, so removed that option to rename

## Testing

Can rename from each appearance of the object individually, no longer see the "Rename" option on the scene context menu.

https://github.com/user-attachments/assets/36fa9c31-49d0-4979-8180-06555e93bf4c




