### PR TITLE
[xrhome] Remove getFileRoute

### DIFF
--- a/reality/cloud/xrhome/src/client/common/app-container-context.tsx
+++ b/reality/cloud/xrhome/src/client/common/app-container-context.tsx
@@ -4,7 +4,6 @@ import type {EditorRouteParams} from '../editor/editor-route'
 
 type AppPathsContextValue = {
   getStudioRoute: (params: EditorRouteParams, state: Record<string, string>) => string
-  getFileRoute: (params: EditorRouteParams) => string
 }
 
 const AppPathsContext = React.createContext<AppPathsContextValue | null>(null)

--- a/reality/cloud/xrhome/src/client/desktop/local-studio-page.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/local-studio-page.tsx
@@ -172,7 +172,6 @@ const LocalStudioPage: React.FC = () => {
 
   const appPathsContext = React.useMemo(() => ({
     getPathForApp: () => getLocalStudioPath(appKey),
-    getFileRoute: () => getLocalStudioPath(appKey),
     getStudioRoute: () => getLocalStudioPath(appKey),
   }), [appKey])
 

--- a/reality/cloud/xrhome/src/client/editor/file-link.tsx
+++ b/reality/cloud/xrhome/src/client/editor/file-link.tsx
@@ -1,22 +1,10 @@
 import React from 'react'
-import {Link} from 'react-router-dom'
-import {createUseStyles} from 'react-jss'
 import {basename} from 'path'
-import type {LocationDescriptor} from 'history'
 
 import type {IAccount, IApp} from '../common/types/models'
 import {useCurrentGit} from '../git/hooks/use-current-git'
-import {useAppPathsContext} from '../common/app-container-context'
-
-const useStyles = createUseStyles({
-  fileLink: {
-    'textDecoration': 'underline',
-    'color': 'inherit',
-    '&:hover': {
-      color: 'inherit',
-    },
-  },
-})
+import {useFileActionsContext} from './files/file-actions-context'
+import {LinkButton} from '../ui/components/link-button'
 
 interface IFileLink {
   account: IAccount
@@ -33,17 +21,13 @@ const makeFileString = (file: string, line?: number, column?: number) => {
 }
 
 const FileLink: React.FC<IFileLink> = ({account, app, file, line, column}) => {
-  const classes = useStyles()
-  const appPaths = useAppPathsContext()
+  const actionsContext = useFileActionsContext()
 
   const fileExists = useCurrentGit(git => !!git.filesByPath[file])
 
-  let link: LocationDescriptor
   let linkText: string
 
   if (fileExists && account && app) {
-    // TODO(christoph): Add line/column to link
-    link = appPaths.getFileRoute(file)
     linkText = makeFileString(file, line, column)
   } else if (file) {
     linkText = basename(file)
@@ -53,11 +37,11 @@ const FileLink: React.FC<IFileLink> = ({account, app, file, line, column}) => {
     return null
   }
 
-  if (link) {
+  if (fileExists) {
     return (
-      <Link className={classes.fileLink} to={link}>
+      <LinkButton onClick={() => actionsContext.onSelect(file)}>
         {linkText}
-      </Link>
+      </LinkButton>
     )
   } else {
     // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/reality/cloud/xrhome/src/client/editor/file-link.tsx
+++ b/reality/cloud/xrhome/src/client/editor/file-link.tsx
@@ -4,7 +4,7 @@ import {basename} from 'path'
 import type {IAccount, IApp} from '../common/types/models'
 import {useCurrentGit} from '../git/hooks/use-current-git'
 import {useFileActionsContext} from './files/file-actions-context'
-import {LinkButton} from '../ui/components/link-button'
+import {BoldButton} from '../ui/components/bold-button'
 
 interface IFileLink {
   account: IAccount
@@ -39,9 +39,9 @@ const FileLink: React.FC<IFileLink> = ({account, app, file, line, column}) => {
 
   if (fileExists) {
     return (
-      <LinkButton onClick={() => actionsContext.onSelect(file)}>
+      <BoldButton onClick={() => actionsContext.onSelect(file)}>
         {linkText}
-      </LinkButton>
+      </BoldButton>
     )
   } else {
     // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/reality/cloud/xrhome/src/client/studio/error-message.tsx
+++ b/reality/cloud/xrhome/src/client/studio/error-message.tsx
@@ -7,8 +7,8 @@ import {
 } from '../editor/editor-file-location'
 import {useStudioComponentsContext} from './studio-components-context'
 import {StaticBanner} from '../ui/components/banner'
-import {LinkButton} from '../ui/components/link-button'
 import {useFileActionsContext} from '../editor/files/file-actions-context'
+import {BoldButton} from '../ui/components/bold-button'
 
 // TODO: Finish translating
 /* eslint-disable local-rules/hardcoded-copy */
@@ -35,11 +35,11 @@ const ErrorMessageLink: React.FC<IErrorMessageLink> = ({firstErrorLocation, firs
   }
 
   return (
-    <LinkButton color='danger' onClick={() => actionsContext.onSelect(firstErrorLocation)}>
+    <BoldButton onClick={() => actionsContext.onSelect(firstErrorLocation)}>
       <span className={classes.errorText}>
         {`[Ln ${firstError.location.startColumn}, Col ${firstError.location.startLine}]`}
       </span>
-    </LinkButton>
+    </BoldButton>
   )
 }
 

--- a/reality/cloud/xrhome/src/client/studio/error-message.tsx
+++ b/reality/cloud/xrhome/src/client/studio/error-message.tsx
@@ -1,27 +1,20 @@
 import React from 'react'
 import type {StudioComponentError} from '@ecs/shared/studio-component'
 import {createUseStyles} from 'react-jss'
-import {Link} from 'react-router-dom'
 
 import {
-  deriveEditorRouteParams, deriveLocationFromKey, extractFilePath, type EditorFileLocation,
+  deriveLocationFromKey, extractFilePath, type EditorFileLocation,
 } from '../editor/editor-file-location'
 import {useStudioComponentsContext} from './studio-components-context'
 import {StaticBanner} from '../ui/components/banner'
-import {blueberry} from '../static/styles/settings'
-import {useAppPathsContext} from '../common/app-container-context'
-import {getHashForFile} from '../common/paths'
+import {LinkButton} from '../ui/components/link-button'
+import {useFileActionsContext} from '../editor/files/file-actions-context'
 
 // TODO: Finish translating
 /* eslint-disable local-rules/hardcoded-copy */
 
 const useStyles = createUseStyles({
-  errorButton: {
-    border: 'none',
-    background: 'none',
-    cursor: 'pointer',
-    color: blueberry,
-  },
+
   errorText: {
     textWrap: 'nowrap',
   },
@@ -35,26 +28,18 @@ interface IErrorMessageLink {
 const ErrorMessageLink: React.FC<IErrorMessageLink> = ({firstErrorLocation, firstError}) => {
   const classes = useStyles()
 
-  const {getFileRoute} = useAppPathsContext()
+  const actionsContext = useFileActionsContext()
 
   if (!firstError.location) {
     return null
   }
 
-  const getFileRouteWithHash = (
-    location: EditorFileLocation, line: number, column: number
-  ) => getFileRoute(deriveEditorRouteParams(location)) +
-  getHashForFile(line, column)
-
   return (
-    <Link to={getFileRouteWithHash(firstErrorLocation,
-      firstError.location.startLine,
-      firstError.location.startColumn + 1)}
-    >
+    <LinkButton color='danger' onClick={() => actionsContext.onSelect(firstErrorLocation)}>
       <span className={classes.errorText}>
         {`[Ln ${firstError.location.startColumn}, Col ${firstError.location.startLine}]`}
       </span>
-    </Link>
+    </LinkButton>
   )
 }
 
@@ -77,8 +62,12 @@ const ErrorMessage: React.FC = () => {
 
   return (
     <StaticBanner type='danger'>
-      {`A total of ${numErrors} error${numErrors > 1 ? 's' : ''}`}
-      <br />
+      {numErrors > 1 &&
+        <>
+          A total of ${numErrors} errors
+          <br />
+        </>
+      }
       {`(${extractFilePath(firstErrorLocation)}): `}
       <br />
       {firstError.message}


### PR DESCRIPTION
## Context

getFileRoute was used when we had a browser-based UI with the current file stored in the URL.

## Testing

Clicking error messages now opens the file in the sidebar

<img width="314" height="175" alt="Screenshot 2026-08-14 at 12 11 01 PM" src="https://github.com/user-attachments/assets/48e89f2e-3fd4-422e-97fd-c33c2e7d39f8" />
