### PR TITLE
fix: keep spotlight target outside light hierarchy

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/light.tsx
+++ b/reality/cloud/xrhome/src/client/studio/light.tsx
@@ -184,12 +184,6 @@ const SpotLightComponent: React.FC<ILightComponent> = (
   useHelper(showHelpers ? lightRef : null, SpotLightHelper)
   useHelper(showHelpers ? shadowCameraRef : null, CameraHelper)
 
-  const target = React.useMemo(() => {
-    const object = new Object3D()
-    object.position.z = 1
-    return object
-  }, [])
-
   useLayoutEffect(() => {
     if (lightRef.current) {
       lightRef.current.castShadow = lightConfig.castShadow
@@ -212,28 +206,33 @@ const SpotLightComponent: React.FC<ILightComponent> = (
     }
   }, [lightConfig, texture])
 
+  const target = React.useMemo(() => {
+    const object = new Object3D()
+    object.position.z = 1
+    return object
+  }, [])
+
   return (
-    <>
-      <spotLight
-        ref={lightRef}
-        color={lightConfig.color}
-        castShadow={lightConfig.castShadow}
-        intensity={intensity}
-        decay={lightConfig.decay}
-        distance={lightConfig.distance}
-        angle={lightConfig.angle}
-        penumbra={lightConfig.penumbra}
-        target={target}
-      >
-        <perspectiveCamera
-          ref={shadowCameraRef}
-          attach='shadow-camera'
-          near={lightConfig.shadowCamera[4]}
-          far={lightConfig.shadowCamera[5]}
-        />
-      </spotLight>
+    <spotLight
+      ref={lightRef}
+      color={lightConfig.color}
+      castShadow={lightConfig.castShadow}
+      intensity={intensity}
+      decay={lightConfig.decay}
+      distance={lightConfig.distance}
+      angle={lightConfig.angle}
+      penumbra={lightConfig.penumbra}
+      target={target}
+      position={[0, 0, 0]}
+    >
+      <perspectiveCamera
+        ref={shadowCameraRef}
+        attach='shadow-camera'
+        near={lightConfig.shadowCamera[4]}
+        far={lightConfig.shadowCamera[5]}
+      />
       <primitive object={target} />
-    </>
+    </spotLight>
   )
 }
 

--- a/reality/cloud/xrhome/src/client/studio/light.tsx
+++ b/reality/cloud/xrhome/src/client/studio/light.tsx
@@ -184,6 +184,12 @@ const SpotLightComponent: React.FC<ILightComponent> = (
   useHelper(showHelpers ? lightRef : null, SpotLightHelper)
   useHelper(showHelpers ? shadowCameraRef : null, CameraHelper)
 
+  const target = React.useMemo(() => {
+    const object = new Object3D()
+    object.position.z = 1
+    return object
+  }, [])
+
   useLayoutEffect(() => {
     if (lightRef.current) {
       lightRef.current.castShadow = lightConfig.castShadow
@@ -203,14 +209,11 @@ const SpotLightComponent: React.FC<ILightComponent> = (
         lightRef.current.shadow.map?.dispose()
         lightRef.current.shadow.map = null
       }
+      lightRef.current.updateMatrixWorld(true)
+      target.updateMatrixWorld(true)
     }
-  }, [lightConfig, texture])
+  }, [lightConfig, texture, target])
 
-  const target = React.useMemo(() => {
-    const object = new Object3D()
-    object.position.z = 1
-    return object
-  }, [])
 
   return (
     <spotLight

--- a/reality/cloud/xrhome/src/client/studio/light.tsx
+++ b/reality/cloud/xrhome/src/client/studio/light.tsx
@@ -209,32 +209,31 @@ const SpotLightComponent: React.FC<ILightComponent> = (
         lightRef.current.shadow.map?.dispose()
         lightRef.current.shadow.map = null
       }
-      lightRef.current.updateMatrixWorld(true)
-      target.updateMatrixWorld(true)
     }
-  }, [lightConfig, texture, target])
-
+  }, [lightConfig, texture])
 
   return (
-    <spotLight
-      ref={lightRef}
-      color={lightConfig.color}
-      castShadow={lightConfig.castShadow}
-      intensity={intensity}
-      decay={lightConfig.decay}
-      distance={lightConfig.distance}
-      angle={lightConfig.angle}
-      penumbra={lightConfig.penumbra}
-      target={target}
-    >
-      <perspectiveCamera
-        ref={shadowCameraRef}
-        attach='shadow-camera'
-        near={lightConfig.shadowCamera[4]}
-        far={lightConfig.shadowCamera[5]}
-      />
+    <>
+      <spotLight
+        ref={lightRef}
+        color={lightConfig.color}
+        castShadow={lightConfig.castShadow}
+        intensity={intensity}
+        decay={lightConfig.decay}
+        distance={lightConfig.distance}
+        angle={lightConfig.angle}
+        penumbra={lightConfig.penumbra}
+        target={target}
+      >
+        <perspectiveCamera
+          ref={shadowCameraRef}
+          attach='shadow-camera'
+          near={lightConfig.shadowCamera[4]}
+          far={lightConfig.shadowCamera[5]}
+        />
+      </spotLight>
       <primitive object={target} />
-    </spotLight>
+    </>
   )
 }
 


### PR DESCRIPTION
Refs #249

Fixes the Spot Light guide misalignment in Studio.

## Changes

- keep the SpotLight target outside the SpotLight hierarchy
- preserve the target as the SpotLight's target
- prevent the target from inheriting the SpotLight transform
- keep the helper and rendered light direction in the same parent coordinate space

## Testing

- npm run ts:check
- repo lint
- reproduced the two-cube scene supplied in #252 review feedback
- verified the helper origin remains aligned with the Spot Light
- verified helper direction updates correctly across substantial X/Y rotations
- verified the rendered spotlight direction follows the helper