### PR TITLE
fix(xrextras): scope loading module CSS namespace

### DIFF
--- a/packages/xrextras/package-lock.json
+++ b/packages/xrextras/package-lock.json
@@ -13,6 +13,8 @@
         "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^6.8.1",
         "html-loader": "^4.2.0",
+        "postcss": "^8.4.24",
+        "postcss-selector-parser": "^6.0.13",
         "style-loader": "^3.3.3",
         "text-loader": "^0.0.1",
         "ts-loader": "^9.4.4",
@@ -2432,9 +2434,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2442,6 +2444,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2717,10 +2720,11 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2765,6 +2769,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -2803,6 +2808,20 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-modules-scope": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
@@ -2816,6 +2835,20 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-modules-values": {
@@ -2838,6 +2871,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3353,10 +3387,11 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6074,9 +6109,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true
     },
     "negotiator": {
@@ -6284,9 +6319,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "picomatch": {
@@ -6331,6 +6366,18 @@
         "icss-utils": "^5.0.0",
         "postcss-selector-parser": "^6.0.2",
         "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+          "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        }
       }
     },
     "postcss-modules-scope": {
@@ -6340,6 +6387,18 @@
       "dev": true,
       "requires": {
         "postcss-selector-parser": "^6.0.4"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+          "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        }
       }
     },
     "postcss-modules-values": {
@@ -6750,9 +6809,9 @@
       "dev": true
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
     },
     "source-map-support": {

--- a/packages/xrextras/package.json
+++ b/packages/xrextras/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "webpack && cp src/entry.js index.js",
+    "test": "node test/css-namespace.test.js",
     "prepack": "npm run clean && npm run build",
     "dev": "webpack server --devtool eval --mode development",
     "clean": "rm -rf dist"

--- a/packages/xrextras/package.json
+++ b/packages/xrextras/package.json
@@ -43,6 +43,8 @@
     "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^6.8.1",
     "html-loader": "^4.2.0",
+    "postcss": "^8.4.24",
+    "postcss-selector-parser": "^6.0.13",
     "style-loader": "^3.3.3",
     "text-loader": "^0.0.1",
     "ts-loader": "^9.4.4",

--- a/packages/xrextras/src/aframe/components/lifecycle-components.ts
+++ b/packages/xrextras/src/aframe/components/lifecycle-components.ts
@@ -263,7 +263,7 @@ const loadingComponent: ComponentDefinition = {
     }
     window.XRExtras ? load() : window.addEventListener('xrextrasloaded', load, {once: true})
 
-    const loadImg = document.querySelector('#loadImage') as any
+    const loadImg = document.querySelector('#xrextras-load-image') as any
 
     if (loadImg) {
       if (this.data.loadImage !== '') {
@@ -273,15 +273,25 @@ const loadingComponent: ComponentDefinition = {
         }
       }
 
-      if (this.data.loadAnimation !== '') {
-        loadImg.classList.remove('spin')
-        if (this.data.loadAnimation !== 'none') {
-          loadImg.classList.add(this.data.loadAnimation)
+    if (this.data.loadAnimation !== '') {
+      loadImg.classList.remove('xrextras-loading-spin')
+
+      const animations: Record<string, string> = {
+        spin: 'xrextras-loading-spin',
+        pulse: 'xrextras-loading-pulse',
+        scale: 'xrextras-loading-scale',
+      }
+
+      if (this.data.loadAnimation !== 'none') {
+        const animation = animations[this.data.loadAnimation]
+        if (animation) {
+          loadImg.classList.add(animation)
+        }
         }
       }
     }
 
-    const loadBackground = document.querySelector('#loadBackground')
+    const loadBackground = document.querySelector('#xrextras-load-background')
 
     if (loadBackground) {
       loadBackground.style.backgroundColor = this.data.loadBackgroundColor

--- a/packages/xrextras/src/loadingmodule/loading-module.css
+++ b/packages/xrextras/src/loadingmodule/loading-module.css
@@ -1,19 +1,19 @@
-#loadingContainer {
+#xrextras-loading-container {
   z-index: 800;
   font-family: 'Nunito-SemiBold', sans-serif;
 }
 
-#loadingContainer #xrextras-load-background {
+#xrextras-load-background {
   z-index: 10;
   background-color: #101118;
   pointer-events: auto;
 }
 
-.xrextras-old-style #loadingContainer #xrextras-load-background {
+.xrextras-old-style #xrextras-load-background {
   background-color: white;
 }
 
-#loadingContainer #xrextras-requesting-camera-permissions {
+#xrextras-requesting-camera-permissions {
   z-index: 11;
   position: absolute;
   top: 0;
@@ -27,14 +27,14 @@
   padding-bottom: 1.75vh;
 }
 
-#loadingContainer #xrextras-requesting-camera-icon {
+#xrextras-requesting-camera-icon {
   display: block;
   margin: 0 auto;
   margin-bottom: 2vh;
   height: 5.5vh;
 }
 
-#loadingContainer #xrextras-load-image {
+#xrextras-load-image {
   position: absolute;
   margin-top: -2.5em;
   margin-left: -2.5em;
@@ -46,15 +46,15 @@
 }
 
 /* camera and micrphone permission related styles */
-#loadingContainer #xrextras-camera-permissions-error-apple, #loadingContainer #xrextras-microphone-permissions-error-apple {
+#xrextras-camera-permissions-error-apple, #xrextras-microphone-permissions-error-apple {
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer #xrextras-camera-permissions-error-apple, .xrextras-old-style #xrextras-microphone-permissions-error-apple {
+.xrextras-old-style #xrextras-camera-permissions-error-apple, .xrextras-old-style #xrextras-microphone-permissions-error-apple {
   background-color: white;
 }
 
-#loadingContainer #xrextras-camera-permissions-error-apple-message, #loadingContainer #xrextras-microphone-permissions-error-apple-message {
+#xrextras-camera-permissions-error-apple-message, #xrextras-microphone-permissions-error-apple-message {
   font-size: 1.75em;
   text-align: center;
   max-width: 90vw;
@@ -64,24 +64,24 @@
   color: white;
 }
 
-.xrextras-old-style #loadingContainer #xrextras-camera-permissions-error-apple-message, .xrextras-old-style #xrextras-microphone-permissions-error-apple-message {
+.xrextras-old-style #xrextras-camera-permissions-error-apple-message, .xrextras-old-style #xrextras-microphone-permissions-error-apple-message {
   color: #323232;
 }
 
-#loadingContainer .xrextras-loading-permission-icon-ios {
+.xrextras-loading-permission-icon-ios {
   display: block;
   margin: 0 auto;
   margin-top: 17vh;
   text-align: center;
 }
-#loadingContainer .xrextras-loading-permission-icon-ios img {
+.xrextras-loading-permission-icon-ios img {
   height: 20vw;
 }
-#loadingContainer .xrextras-loading-permission-icon-ios img + img {
+.xrextras-loading-permission-icon-ios img + img {
   margin-left: 10vw;
 }
 
-#loadingContainer .xrextras-loading-bottom-message {
+.xrextras-loading-bottom-message {
   color: white;
   padding: 0 5vw;
   position: absolute;
@@ -90,7 +90,7 @@
   font-size: 1.25em;
 }
 
-#loadingContainer #xrextras-camera-permissions-error-android, #loadingContainer #xrextras-microphone-permissions-error-android {
+#xrextras-camera-permissions-error-android, #xrextras-microphone-permissions-error-android {
   padding: 2vh 0;
   display: flex;
   flex-direction: column;
@@ -100,13 +100,13 @@
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer #xrextras-camera-permissions-error-android, .xrextras-old-style #xrextras-microphone-permissions-error-android {
+.xrextras-old-style #xrextras-camera-permissions-error-android, .xrextras-old-style #xrextras-microphone-permissions-error-android {
   background-color: white;
 }
 
 /* device motion permission related styles */
 
-#loadingContainer #xrextras-device-motion-error-apple {
+#xrextras-device-motion-error-apple {
   padding: 3vh 2vh;
   display: flex;
   flex-direction: column;
@@ -117,38 +117,38 @@
   color: white;
 }
 
-.xrextras-old-style #loadingContainer #xrextras-device-motion-error-apple {
+.xrextras-old-style #xrextras-device-motion-error-apple {
   color: #2D2E43;
   background-color: white;
 }
 
-#loadingContainer #xrextras-link-out-view-android,
-#loadingContainer #xrextras-copy-link-view-android {
+#xrextras-link-out-view-android,
+#xrextras-copy-link-view-android {
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer #xrextras-link-out-view-android,
-.xrextras-old-style #loadingContainer #xrextras-copy-link-view-android {
+.xrextras-old-style #xrextras-link-out-view-android,
+.xrextras-old-style #xrextras-copy-link-view-android {
   background-color: #fff;
 }
 
-#loadingContainer .xrextras-loading-permission-error {
+.xrextras-loading-permission-error {
   padding: 3vh 5vh;
   font-size: 3.5vh;
   color: #fff;
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-permission-error {
+.xrextras-old-style .xrextras-loading-permission-error {
   color: #323232;
   background-color: white;
 }
 
-#loadingContainer .xrextras-loading-permission-error>h1 {
+.xrextras-loading-permission-error>h1 {
   font-size: 1.3em;
 }
 
-#loadingContainer .xrextras-loading-main-button {
+.xrextras-loading-main-button {
   border: none;
   outline: none;
   background-color: #AD50FF;
@@ -160,11 +160,11 @@
   border-radius: 0.5em;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-main-button {
+.xrextras-old-style .xrextras-loading-main-button {
   background-color: #7611B7;
 }
 
-#loadingContainer .xrextras-loading-start-ar-button {
+.xrextras-loading-start-ar-button {
   position: fixed;
   bottom: 25%;
   left: 50%;
@@ -181,23 +181,23 @@
   border-radius: 10px;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-start-ar-button {
+.xrextras-old-style .xrextras-loading-start-ar-button {
   background-color: #7611b7;
 }
 
-#loadingContainer .xrextras-loading-permission-icon {
+.xrextras-loading-permission-icon {
   overflow: hidden;
   flex: 0 0 auto;
   margin-bottom: 2vh;
 }
 
-#loadingContainer .xrextras-loading-permission-icon img {
+.xrextras-loading-permission-icon img {
   display: block;
   margin: 0 auto;
   height: 5vh;
 }
 
-#loadingContainer #xrextras-camera-selection-world-tracking-error {
+#xrextras-camera-selection-world-tracking-error {
   z-index: 999;
   position: absolute;
   top: 0;
@@ -209,17 +209,17 @@
   padding: 3vh 0;
 }
 
-#loadingContainer .xrextras-loading-error-header {
+.xrextras-loading-error-header {
   font-size: 3.5vh;
   flex: 0 0 auto;
   color: white;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-error-header {
+.xrextras-old-style .xrextras-loading-error-header {
   color: #323232;
 }
 
-#loadingContainer .xrextras-loading-error-footer {
+.xrextras-loading-error-footer {
   font-size: 3vh;
   line-height: 5.5vh;
   flex: 0 0 auto;
@@ -228,18 +228,18 @@
   color: white;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-error-footer {
+.xrextras-old-style .xrextras-loading-error-footer {
   color: #323232;
 }
 
-#loadingContainer .xrextras-loading-error-footer img {
+.xrextras-loading-error-footer img {
   display: block;
   height: 5vh;
   margin: 0 auto;
   margin-bottom: 2vh;
 }
 
-#loadingContainer .xrextras-loading-error-instructions {
+.xrextras-loading-error-instructions {
   font-family: 'Nunito', sans-serif;
   color: #fff;
   font-size: 2.5vh;
@@ -249,22 +249,22 @@
   flex: 0 0 auto;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-error-instructions {
+.xrextras-old-style .xrextras-loading-error-instructions {
   color: #2D2E43;
 }
 
-#loadingContainer .xrextras-loading-error-instructions>li {
+.xrextras-loading-error-instructions>li {
   position: relative;
   margin-bottom: 4.5vh;
 }
 
-#loadingContainer .xrextras-loading-error-instructions>li>img {
+.xrextras-loading-error-instructions>li>img {
   max-height: 3vh;
   vertical-align: middle;
   margin: 0 .5vh;
 }
 
-#loadingContainer .xrextras-loading-error-instructions>li:before {
+.xrextras-loading-error-instructions>li:before {
   font-family: 'Nunito', sans-serif;
   position: absolute;
   width: 40px;
@@ -281,31 +281,31 @@
   content: counter(line);
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-error-instructions>li:before {
+.xrextras-old-style .xrextras-loading-error-instructions>li:before {
   background-color: rgba(218, 209, 228, 128);
 }
 
-#loadingContainer .xrextras-loading-highlight {
+.xrextras-loading-highlight {
   color: white;
   font-family: 'Nunito-SemiBold', sans-serif;
   font-weight: 800;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-highlight {
+.xrextras-old-style .xrextras-loading-highlight {
   color: #7611B7;
 }
 
-#loadingContainer .xrextras-loading-camera-instruction-block {
+.xrextras-loading-camera-instruction-block {
   display: inline-block;
   background-color: #8083A2;
   padding: 1vh;
 }
 
-.xrextras-old-style #loadingContainer .xrextras-loading-camera-instruction-block {
+.xrextras-old-style .xrextras-loading-camera-instruction-block {
   background-color: #EBEBEB;
 }
 
-#loadingContainer .xrextras-loading-camera-instruction-button {
+.xrextras-loading-camera-instruction-button {
   display: inline-block;
   padding: 1vh;
   background-color: #359AFF;
@@ -314,22 +314,7 @@
   box-shadow: 0 .125vh .25vh rgba(0, 0, 0, 0.5);
 }
 
-body:not(.xrextras-old-style) #loadingContainer .prompt-box-8w {
-  background-color: #3A3B55;
-  color: #fff;
-  text-align: center;
-}
-
-body:not(.xrextras-old-style) #loadingContainer .prompt-button-8w {
-  background-color: #8083A2;
-  border-radius: 10px;
-}
-
-body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
-  background-color: #AD50FF;
-}
-
-#loadingContainer .xrextras-loading-fade-out {
+.xrextras-loading-fade-out {
   animation: xrextras-loading-fade-out 0.3s linear forwards;
 }
 
@@ -342,7 +327,7 @@ body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   }
 }
 
-#loadingContainer .xrextras-loading-spin {
+.xrextras-loading-spin {
   animation: xrextras-loading-spin 1.1s cubic-bezier(0.785, 0.135, 0.150, 0.860) infinite both;
 }
 
@@ -355,7 +340,7 @@ body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   }
 }
 
-#loadingContainer .xrextras-loading-scale {
+.xrextras-loading-scale {
   -webkit-animation: xrextras-loading-scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
   animation: xrextras-loading-scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
 }
@@ -371,7 +356,7 @@ body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   }
 }
 
-#loadingContainer .xrextras-loading-pulse {
+.xrextras-loading-pulse {
   -webkit-animation: xrextras-loading-pulse 1s ease-in-out infinite both;
   animation: xrextras-loading-pulse 1s ease-in-out infinite both;
 }

--- a/packages/xrextras/src/loadingmodule/loading-module.css
+++ b/packages/xrextras/src/loadingmodule/loading-module.css
@@ -3,18 +3,17 @@
   font-family: 'Nunito-SemiBold', sans-serif;
 }
 
-#loadingContainer #loadBackground {
+#loadingContainer #xrextras-load-background {
   z-index: 10;
   background-color: #101118;
   pointer-events: auto;
 }
 
-.xrextras-old-style #loadingContainer #loadBackground {
+.xrextras-old-style #loadingContainer #xrextras-load-background {
   background-color: white;
 }
 
-
-#loadingContainer #requestingCameraPermissions {
+#loadingContainer #xrextras-requesting-camera-permissions {
   z-index: 11;
   position: absolute;
   top: 0;
@@ -28,14 +27,14 @@
   padding-bottom: 1.75vh;
 }
 
-#loadingContainer #requestingCameraIcon {
+#loadingContainer #xrextras-requesting-camera-icon {
   display: block;
   margin: 0 auto;
   margin-bottom: 2vh;
   height: 5.5vh;
 }
 
-#loadingContainer #loadImage {
+#loadingContainer #xrextras-load-image {
   position: absolute;
   margin-top: -2.5em;
   margin-left: -2.5em;
@@ -47,15 +46,15 @@
 }
 
 /* camera and micrphone permission related styles */
-#loadingContainer #cameraPermissionsErrorApple, #loadingContainer #microphonePermissionsErrorApple {
+#loadingContainer #xrextras-camera-permissions-error-apple, #loadingContainer #xrextras-microphone-permissions-error-apple {
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer #cameraPermissionsErrorApple, .xrextras-old-style #microphonePermissionsErrorApple {
+.xrextras-old-style #loadingContainer #xrextras-camera-permissions-error-apple, .xrextras-old-style #xrextras-microphone-permissions-error-apple {
   background-color: white;
 }
 
-#loadingContainer #cameraPermissionsErrorAppleMessage, #loadingContainer #microphonePermissionsErrorAppleMessage {
+#loadingContainer #xrextras-camera-permissions-error-apple-message, #loadingContainer #xrextras-microphone-permissions-error-apple-message {
   font-size: 1.75em;
   text-align: center;
   max-width: 90vw;
@@ -65,24 +64,24 @@
   color: white;
 }
 
-.xrextras-old-style #loadingContainer #cameraPermissionsErrorAppleMessage, .xrextras-old-style #microphonePermissionsErrorAppleMessage {
+.xrextras-old-style #loadingContainer #xrextras-camera-permissions-error-apple-message, .xrextras-old-style #xrextras-microphone-permissions-error-apple-message {
   color: #323232;
 }
 
-#loadingContainer .permissionIconIos {
+#loadingContainer .xrextras-loading-permission-icon-ios {
   display: block;
   margin: 0 auto;
   margin-top: 17vh;
   text-align: center;
 }
-#loadingContainer .permissionIconIos img {
+#loadingContainer .xrextras-loading-permission-icon-ios img {
   height: 20vw;
 }
-#loadingContainer .permissionIconIos img + img {
+#loadingContainer .xrextras-loading-permission-icon-ios img + img {
   margin-left: 10vw;
 }
 
-#loadingContainer .bottom-message {
+#loadingContainer .xrextras-loading-bottom-message {
   color: white;
   padding: 0 5vw;
   position: absolute;
@@ -91,7 +90,7 @@
   font-size: 1.25em;
 }
 
-#loadingContainer #cameraPermissionsErrorAndroid, #loadingContainer #microphonePermissionsErrorAndroid {
+#loadingContainer #xrextras-camera-permissions-error-android, #loadingContainer #xrextras-microphone-permissions-error-android {
   padding: 2vh 0;
   display: flex;
   flex-direction: column;
@@ -101,13 +100,13 @@
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer #cameraPermissionsErrorAndroid, .xrextras-old-style #microphonePermissionsErrorAndroid {
+.xrextras-old-style #loadingContainer #xrextras-camera-permissions-error-android, .xrextras-old-style #xrextras-microphone-permissions-error-android {
   background-color: white;
 }
 
 /* device motion permission related styles */
 
-#loadingContainer #deviceMotionErrorApple {
+#loadingContainer #xrextras-device-motion-error-apple {
   padding: 3vh 2vh;
   display: flex;
   flex-direction: column;
@@ -118,36 +117,38 @@
   color: white;
 }
 
-.xrextras-old-style #loadingContainer #deviceMotionErrorApple {
+.xrextras-old-style #loadingContainer #xrextras-device-motion-error-apple {
   color: #2D2E43;
   background-color: white;
 }
 
-#loadingContainer #linkOutViewAndroid, #loadingContainer #copyLinkViewAndroid {
+#loadingContainer #xrextras-link-out-view-android,
+#loadingContainer #xrextras-copy-link-view-android {
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer #linkOutViewAndroid, .xrextras-old-style #copyLinkViewAndroid {
+.xrextras-old-style #loadingContainer #xrextras-link-out-view-android,
+.xrextras-old-style #loadingContainer #xrextras-copy-link-view-android {
   background-color: #fff;
 }
 
-#loadingContainer .permission-error {
+#loadingContainer .xrextras-loading-permission-error {
   padding: 3vh 5vh;
   font-size: 3.5vh;
   color: #fff;
   background-color: #101118;
 }
 
-.xrextras-old-style #loadingContainer .permission-error {
+.xrextras-old-style #loadingContainer .xrextras-loading-permission-error {
   color: #323232;
   background-color: white;
 }
 
-#loadingContainer .permission-error>h1 {
+#loadingContainer .xrextras-loading-permission-error>h1 {
   font-size: 1.3em;
 }
 
-#loadingContainer .main-button {
+#loadingContainer .xrextras-loading-main-button {
   border: none;
   outline: none;
   background-color: #AD50FF;
@@ -159,11 +160,11 @@
   border-radius: 0.5em;
 }
 
-.xrextras-old-style #loadingContainer .main-button {
+.xrextras-old-style #loadingContainer .xrextras-loading-main-button {
   background-color: #7611B7;
 }
 
-#loadingContainer .start-ar-button {
+#loadingContainer .xrextras-loading-start-ar-button {
   position: fixed;
   bottom: 25%;
   left: 50%;
@@ -180,23 +181,23 @@
   border-radius: 10px;
 }
 
-.xrextras-old-style #loadingContainer .start-ar-button {
+.xrextras-old-style #loadingContainer .xrextras-loading-start-ar-button {
   background-color: #7611b7;
 }
 
-#loadingContainer .permissionIcon {
+#loadingContainer .xrextras-loading-permission-icon {
   overflow: hidden;
   flex: 0 0 auto;
   margin-bottom: 2vh;
 }
 
-#loadingContainer .permissionIcon img {
+#loadingContainer .xrextras-loading-permission-icon img {
   display: block;
   margin: 0 auto;
   height: 5vh;
 }
 
-#loadingContainer #cameraSelectionWorldTrackingError {
+#loadingContainer #xrextras-camera-selection-world-tracking-error {
   z-index: 999;
   position: absolute;
   top: 0;
@@ -208,17 +209,17 @@
   padding: 3vh 0;
 }
 
-#loadingContainer .loading-error-header {
+#loadingContainer .xrextras-loading-error-header {
   font-size: 3.5vh;
   flex: 0 0 auto;
   color: white;
 }
 
-.xrextras-old-style #loadingContainer .loading-error-header {
+.xrextras-old-style #loadingContainer .xrextras-loading-error-header {
   color: #323232;
 }
 
-#loadingContainer .loading-error-footer {
+#loadingContainer .xrextras-loading-error-footer {
   font-size: 3vh;
   line-height: 5.5vh;
   flex: 0 0 auto;
@@ -227,18 +228,18 @@
   color: white;
 }
 
-.xrextras-old-style #loadingContainer .loading-error-footer {
+.xrextras-old-style #loadingContainer .xrextras-loading-error-footer {
   color: #323232;
 }
 
-#loadingContainer .loading-error-footer img {
+#loadingContainer .xrextras-loading-error-footer img {
   display: block;
   height: 5vh;
   margin: 0 auto;
   margin-bottom: 2vh;
 }
 
-#loadingContainer .loading-error-instructions {
+#loadingContainer .xrextras-loading-error-instructions {
   font-family: 'Nunito', sans-serif;
   color: #fff;
   font-size: 2.5vh;
@@ -248,22 +249,22 @@
   flex: 0 0 auto;
 }
 
-.xrextras-old-style #loadingContainer .loading-error-instructions {
+.xrextras-old-style #loadingContainer .xrextras-loading-error-instructions {
   color: #2D2E43;
 }
 
-#loadingContainer .loading-error-instructions>li {
+#loadingContainer .xrextras-loading-error-instructions>li {
   position: relative;
   margin-bottom: 4.5vh;
 }
 
-#loadingContainer .loading-error-instructions>li>img {
+#loadingContainer .xrextras-loading-error-instructions>li>img {
   max-height: 3vh;
   vertical-align: middle;
   margin: 0 .5vh;
 }
 
-#loadingContainer .loading-error-instructions>li:before {
+#loadingContainer .xrextras-loading-error-instructions>li:before {
   font-family: 'Nunito', sans-serif;
   position: absolute;
   width: 40px;
@@ -280,31 +281,31 @@
   content: counter(line);
 }
 
-.xrextras-old-style #loadingContainer .loading-error-instructions>li:before {
+.xrextras-old-style #loadingContainer .xrextras-loading-error-instructions>li:before {
   background-color: rgba(218, 209, 228, 128);
 }
 
-#loadingContainer .highlight {
+#loadingContainer .xrextras-loading-highlight {
   color: white;
   font-family: 'Nunito-SemiBold', sans-serif;
   font-weight: 800;
 }
 
-.xrextras-old-style #loadingContainer .highlight {
+.xrextras-old-style #loadingContainer .xrextras-loading-highlight {
   color: #7611B7;
 }
 
-#loadingContainer .camera-instruction-block {
+#loadingContainer .xrextras-loading-camera-instruction-block {
   display: inline-block;
   background-color: #8083A2;
   padding: 1vh;
 }
 
-.xrextras-old-style #loadingContainer .camera-instruction-block {
+.xrextras-old-style #loadingContainer .xrextras-loading-camera-instruction-block {
   background-color: #EBEBEB;
 }
 
-#loadingContainer .camera-instruction-button {
+#loadingContainer .xrextras-loading-camera-instruction-button {
   display: inline-block;
   padding: 1vh;
   background-color: #359AFF;
@@ -328,7 +329,7 @@ body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   background-color: #AD50FF;
 }
 
-#loadingContainer .fade-out {
+#loadingContainer .xrextras-loading-fade-out {
   animation: xrextras-loading-fade-out 0.3s linear forwards;
 }
 
@@ -341,7 +342,7 @@ body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   }
 }
 
-#loadingContainer .spin {
+#loadingContainer .xrextras-loading-spin {
   animation: xrextras-loading-spin 1.1s cubic-bezier(0.785, 0.135, 0.150, 0.860) infinite both;
 }
 
@@ -354,7 +355,7 @@ body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   }
 }
 
-#loadingContainer .scale {
+#loadingContainer .xrextras-loading-scale {
   -webkit-animation: xrextras-loading-scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
   animation: xrextras-loading-scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
 }
@@ -370,7 +371,7 @@ body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   }
 }
 
-#loadingContainer .pulse {
+#loadingContainer .xrextras-loading-pulse {
   -webkit-animation: xrextras-loading-pulse 1s ease-in-out infinite both;
   animation: xrextras-loading-pulse 1s ease-in-out infinite both;
 }

--- a/packages/xrextras/src/loadingmodule/loading-module.css
+++ b/packages/xrextras/src/loadingmodule/loading-module.css
@@ -3,17 +3,18 @@
   font-family: 'Nunito-SemiBold', sans-serif;
 }
 
-#loadBackground {
+#loadingContainer #loadBackground {
   z-index: 10;
   background-color: #101118;
   pointer-events: auto;
 }
 
-.xrextras-old-style #loadBackground {
+.xrextras-old-style #loadingContainer #loadBackground {
   background-color: white;
 }
 
-#requestingCameraPermissions {
+
+#loadingContainer #requestingCameraPermissions {
   z-index: 11;
   position: absolute;
   top: 0;
@@ -27,14 +28,14 @@
   padding-bottom: 1.75vh;
 }
 
-#requestingCameraIcon {
+#loadingContainer #requestingCameraIcon {
   display: block;
   margin: 0 auto;
   margin-bottom: 2vh;
   height: 5.5vh;
 }
 
-#loadImage {
+#loadingContainer #loadImage {
   position: absolute;
   margin-top: -2.5em;
   margin-left: -2.5em;
@@ -46,15 +47,15 @@
 }
 
 /* camera and micrphone permission related styles */
-#cameraPermissionsErrorApple, #microphonePermissionsErrorApple {
+#loadingContainer #cameraPermissionsErrorApple, #loadingContainer #microphonePermissionsErrorApple {
   background-color: #101118;
 }
 
-.xrextras-old-style #cameraPermissionsErrorApple, .xrextras-old-style #microphonePermissionsErrorApple {
+.xrextras-old-style #loadingContainer #cameraPermissionsErrorApple, .xrextras-old-style #microphonePermissionsErrorApple {
   background-color: white;
 }
 
-#cameraPermissionsErrorAppleMessage, #microphonePermissionsErrorAppleMessage {
+#loadingContainer #cameraPermissionsErrorAppleMessage, #loadingContainer #microphonePermissionsErrorAppleMessage {
   font-size: 1.75em;
   text-align: center;
   max-width: 90vw;
@@ -64,24 +65,24 @@
   color: white;
 }
 
-.xrextras-old-style #cameraPermissionsErrorAppleMessage, .xrextras-old-style #microphonePermissionsErrorAppleMessage {
+.xrextras-old-style #loadingContainer #cameraPermissionsErrorAppleMessage, .xrextras-old-style #microphonePermissionsErrorAppleMessage {
   color: #323232;
 }
 
-.permissionIconIos {
+#loadingContainer .permissionIconIos {
   display: block;
   margin: 0 auto;
   margin-top: 17vh;
   text-align: center;
 }
-.permissionIconIos img {
+#loadingContainer .permissionIconIos img {
   height: 20vw;
 }
-.permissionIconIos img + img {
+#loadingContainer .permissionIconIos img + img {
   margin-left: 10vw;
 }
 
-.bottom-message {
+#loadingContainer .bottom-message {
   color: white;
   padding: 0 5vw;
   position: absolute;
@@ -90,7 +91,7 @@
   font-size: 1.25em;
 }
 
-#cameraPermissionsErrorAndroid, #microphonePermissionsErrorAndroid {
+#loadingContainer #cameraPermissionsErrorAndroid, #loadingContainer #microphonePermissionsErrorAndroid {
   padding: 2vh 0;
   display: flex;
   flex-direction: column;
@@ -100,13 +101,13 @@
   background-color: #101118;
 }
 
-.xrextras-old-style #cameraPermissionsErrorAndroid, .xrextras-old-style #microphonePermissionsErrorAndroid {
+.xrextras-old-style #loadingContainer #cameraPermissionsErrorAndroid, .xrextras-old-style #microphonePermissionsErrorAndroid {
   background-color: white;
 }
 
 /* device motion permission related styles */
 
-#deviceMotionErrorApple {
+#loadingContainer #deviceMotionErrorApple {
   padding: 3vh 2vh;
   display: flex;
   flex-direction: column;
@@ -117,36 +118,36 @@
   color: white;
 }
 
-.xrextras-old-style #deviceMotionErrorApple {
+.xrextras-old-style #loadingContainer #deviceMotionErrorApple {
   color: #2D2E43;
   background-color: white;
 }
 
-#linkOutViewAndroid, #copyLinkViewAndroid {
+#loadingContainer #linkOutViewAndroid, #loadingContainer #copyLinkViewAndroid {
   background-color: #101118;
 }
 
-.xrextras-old-style #linkOutViewAndroid, .xrextras-old-style #copyLinkViewAndroid {
+.xrextras-old-style #loadingContainer #linkOutViewAndroid, .xrextras-old-style #copyLinkViewAndroid {
   background-color: #fff;
 }
 
-.permission-error {
+#loadingContainer .permission-error {
   padding: 3vh 5vh;
   font-size: 3.5vh;
   color: #fff;
   background-color: #101118;
 }
 
-.xrextras-old-style .permission-error {
+.xrextras-old-style #loadingContainer .permission-error {
   color: #323232;
   background-color: white;
 }
 
-.permission-error>h1 {
+#loadingContainer .permission-error>h1 {
   font-size: 1.3em;
 }
 
-.main-button {
+#loadingContainer .main-button {
   border: none;
   outline: none;
   background-color: #AD50FF;
@@ -158,11 +159,11 @@
   border-radius: 0.5em;
 }
 
-.xrextras-old-style .main-button {
+.xrextras-old-style #loadingContainer .main-button {
   background-color: #7611B7;
 }
 
-.start-ar-button {
+#loadingContainer .start-ar-button {
   position: fixed;
   bottom: 25%;
   left: 50%;
@@ -179,23 +180,23 @@
   border-radius: 10px;
 }
 
-.xrextras-old-style .start-ar-button {
+.xrextras-old-style #loadingContainer .start-ar-button {
   background-color: #7611b7;
 }
 
-.permissionIcon {
+#loadingContainer .permissionIcon {
   overflow: hidden;
   flex: 0 0 auto;
   margin-bottom: 2vh;
 }
 
-.permissionIcon img {
+#loadingContainer .permissionIcon img {
   display: block;
   margin: 0 auto;
   height: 5vh;
 }
 
-#cameraSelectionWorldTrackingError {
+#loadingContainer #cameraSelectionWorldTrackingError {
   z-index: 999;
   position: absolute;
   top: 0;
@@ -207,17 +208,17 @@
   padding: 3vh 0;
 }
 
-.loading-error-header {
+#loadingContainer .loading-error-header {
   font-size: 3.5vh;
   flex: 0 0 auto;
   color: white;
 }
 
-.xrextras-old-style .loading-error-header {
+.xrextras-old-style #loadingContainer .loading-error-header {
   color: #323232;
 }
 
-.loading-error-footer {
+#loadingContainer .loading-error-footer {
   font-size: 3vh;
   line-height: 5.5vh;
   flex: 0 0 auto;
@@ -226,18 +227,18 @@
   color: white;
 }
 
-.xrextras-old-style .loading-error-footer {
+.xrextras-old-style #loadingContainer .loading-error-footer {
   color: #323232;
 }
 
-.loading-error-footer img {
+#loadingContainer .loading-error-footer img {
   display: block;
   height: 5vh;
   margin: 0 auto;
   margin-bottom: 2vh;
 }
 
-.loading-error-instructions {
+#loadingContainer .loading-error-instructions {
   font-family: 'Nunito', sans-serif;
   color: #fff;
   font-size: 2.5vh;
@@ -247,22 +248,22 @@
   flex: 0 0 auto;
 }
 
-.xrextras-old-style .loading-error-instructions {
+.xrextras-old-style #loadingContainer .loading-error-instructions {
   color: #2D2E43;
 }
 
-.loading-error-instructions>li {
+#loadingContainer .loading-error-instructions>li {
   position: relative;
   margin-bottom: 4.5vh;
 }
 
-.loading-error-instructions>li>img {
+#loadingContainer .loading-error-instructions>li>img {
   max-height: 3vh;
   vertical-align: middle;
   margin: 0 .5vh;
 }
 
-.loading-error-instructions>li:before {
+#loadingContainer .loading-error-instructions>li:before {
   font-family: 'Nunito', sans-serif;
   position: absolute;
   width: 40px;
@@ -279,31 +280,31 @@
   content: counter(line);
 }
 
-.xrextras-old-style .loading-error-instructions>li:before {
+.xrextras-old-style #loadingContainer .loading-error-instructions>li:before {
   background-color: rgba(218, 209, 228, 128);
 }
 
-.highlight {
+#loadingContainer .highlight {
   color: white;
   font-family: 'Nunito-SemiBold', sans-serif;
   font-weight: 800;
 }
 
-.xrextras-old-style .highlight {
+.xrextras-old-style #loadingContainer .highlight {
   color: #7611B7;
 }
 
-.camera-instruction-block {
+#loadingContainer .camera-instruction-block {
   display: inline-block;
   background-color: #8083A2;
   padding: 1vh;
 }
 
-.xrextras-old-style .camera-instruction-block {
+.xrextras-old-style #loadingContainer .camera-instruction-block {
   background-color: #EBEBEB;
 }
 
-.camera-instruction-button {
+#loadingContainer .camera-instruction-button {
   display: inline-block;
   padding: 1vh;
   background-color: #359AFF;
@@ -312,26 +313,26 @@
   box-shadow: 0 .125vh .25vh rgba(0, 0, 0, 0.5);
 }
 
-body:not(.xrextras-old-style) .prompt-box-8w {
+body:not(.xrextras-old-style) #loadingContainer .prompt-box-8w {
   background-color: #3A3B55;
   color: #fff;
   text-align: center;
 }
 
-body:not(.xrextras-old-style) .prompt-button-8w {
+body:not(.xrextras-old-style) #loadingContainer .prompt-button-8w {
   background-color: #8083A2;
   border-radius: 10px;
 }
 
-body:not(.xrextras-old-style) .button-primary-8w {
+body:not(.xrextras-old-style) #loadingContainer .button-primary-8w {
   background-color: #AD50FF;
 }
 
-.fade-out {
-  animation: fade-out 0.3s linear forwards;
+#loadingContainer .fade-out {
+  animation: xrextras-loading-fade-out 0.3s linear forwards;
 }
 
-@keyframes fade-out {
+@keyframes xrextras-loading-fade-out {
   0% {
     opacity: 1;
   }
@@ -340,11 +341,11 @@ body:not(.xrextras-old-style) .button-primary-8w {
   }
 }
 
-.spin {
-  animation: spin 1.1s cubic-bezier(0.785, 0.135, 0.150, 0.860) infinite both;
+#loadingContainer .spin {
+  animation: xrextras-loading-spin 1.1s cubic-bezier(0.785, 0.135, 0.150, 0.860) infinite both;
 }
 
-@keyframes spin {
+@keyframes xrextras-loading-spin {
   0% {
     transform: rotate(0);
   }
@@ -353,12 +354,12 @@ body:not(.xrextras-old-style) .button-primary-8w {
   }
 }
 
-.scale {
-  -webkit-animation: scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
-  animation: scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
+#loadingContainer .scale {
+  -webkit-animation: xrextras-loading-scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
+  animation: xrextras-loading-scale 1s cubic-bezier(0.455, 0.030, 0.515, 0.955) infinite alternate-reverse both;
 }
 
-@keyframes scale {
+@keyframes xrextras-loading-scale {
   0% {
     -webkit-transform: scale(0.5);
     transform: scale(0.5);
@@ -369,12 +370,12 @@ body:not(.xrextras-old-style) .button-primary-8w {
   }
 }
 
-.pulse {
-  -webkit-animation: pulse 1s ease-in-out infinite both;
-  animation: pulse 1s ease-in-out infinite both;
+#loadingContainer .pulse {
+  -webkit-animation: xrextras-loading-pulse 1s ease-in-out infinite both;
+  animation: xrextras-loading-pulse 1s ease-in-out infinite both;
 }
 
-@keyframes pulse {
+@keyframes xrextras-loading-pulse {
   0% {
     -webkit-transform: scale(1);
     transform: scale(1);

--- a/packages/xrextras/src/loadingmodule/loading-module.html
+++ b/packages/xrextras/src/loadingmodule/loading-module.html
@@ -1,71 +1,71 @@
 <div id="loadingContainer" class="absolute-fill">
   <!--Loading screen-->
-  <div id="loadBackground" class="absolute-fill">
-    <div id="loadImageContainer" class="absolute-fill">
-      <img src="./load-grad.png" id="loadImage" class="spin" />
+  <div id="xrextras-load-background" class="absolute-fill">
+    <div id="xrextras-load-image-container" class="absolute-fill">
+      <img src="./load-grad.png" id="xrextras-load-image" class="xrextras-loading-spin" />
       <img class='foreground-image poweredby-img'
         src="../almosttheremodule/poweredby-horiz-white.svg" />
     </div>
   </div>
 
   <!--Camera Permissions-->
-  <div id="requestingCameraPermissions" class="hidden">
-    <img id="requestingCameraIcon" src="./camera.svg" />
+  <div id="xrextras-requesting-camera-permissions" class="hidden">
+    <img id="xrextras-requesting-camera-icon" src="./camera.svg" />
     Tap 'Allow' to access AR
   </div>
 
   <!--Permission error, camera, iOS-->
-  <div id="cameraPermissionsErrorApple" class="absolute-fill hidden">
-    <div class="permissionIconIos">
+  <div id="xrextras-camera-permissions-error-apple" class="absolute-fill hidden">
+    <div class="xrextras-loading-permission-icon-ios">
       <img class='foreground-image' src="./camera.svg" />
     </div>
-    <p id="cameraPermissionsErrorAppleMessage">
+    <p id="xrextras-camera-permissions-error-apple-message">
       Reload the page and enable camera access
     </p>
-    <div class='bottom-message'>
+    <div class='xrextras-loading-bottom-message'>
       Ensure camera access is allowed in <span class='wk-app-name'></span> app settings
     </div>
   </div>
 
   <!--Permission error, camera, Android-->
-  <div id="cameraPermissionsErrorAndroid" class="absolute-fill hidden">
-    <div class="permissionIcon">
+  <div id="xrextras-camera-permissions-error-android" class="absolute-fill hidden">
+    <div class="xrextras-loading-permission-icon">
       <img class='foreground-image' src="./camera.svg" />
     </div>
-    <div class="loading-error-header">Let's enable your camera</div>
-    <ol class="loading-error-instructions">
+    <div class="xrextras-loading-error-header">Let's enable your camera</div>
+    <ol class="xrextras-loading-error-instructions">
       <li>Tap the <img class='foreground-image' src="./dots.svg"> in the top right
       </li>
       <li>Tap Settings</li>
-      <li class="chrome-instruction hidden">
-        <span class="highlight">Site settings</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-highlight">Site settings</span>
       </li>
-      <li class="chrome-instruction hidden">
-        <span class="highlight">Camera</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-highlight">Camera</span>
       </li>
-      <li class="chrome-instruction hidden">
-        <span class="highlight">Blocked</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-highlight">Blocked</span>
         <br>
-        <span class="camera-instruction-block domain-view">apps.8thwall.com</span>
+        <span class="xrextras-loading-camera-instruction-block xrextras-loading-domain-view">apps.8thwall.com</span>
       </li>
-      <li class="chrome-instruction hidden">
-        <span class="camera-instruction-button">CLEAR & RESET</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-camera-instruction-button">CLEAR & RESET</span>
       </li>
-      <li class="samsung-instruction hidden">
-        <span class="highlight">Advanced</span>
+      <li class="xrextras-loading-samsung-instruction hidden">
+        <span class="xrextras-loading-highlight">Advanced</span>
       </li>
-      <li class="samsung-instruction hidden">
-        <span class="highlight">Manage website data</span>
+      <li class="xrextras-loading-samsung-instruction hidden">
+        <span class="xrextras-loading-highlight">Manage website data</span>
       </li>
-      <li class="samsung-instruction hidden">
+      <li class="xrextras-loading-samsung-instruction hidden">
         Press and hold<br>
-        <span class="camera-instruction-block domain-view">apps.8thwall.com</span>
+        <span class="xrextras-loading-camera-instruction-block xrextras-loading-domain-view">apps.8thwall.com</span>
       </li>
-      <li class="samsung-instruction hidden">
-        <span class="highlight" style="color: #1500ba">DELETE</span>
+      <li class="xrextras-loading-samsung-instruction hidden">
+        <span class="xrextras-loading-highlight" style="color: #1500ba">DELETE</span>
       </li>
     </ol>
-    <div class="loading-error-footer">
+    <div class="xrextras-loading-error-footer">
       <img class='foreground-image' style="transform: rotate(130deg);"
         src="./reload.svg" />
       Then, reload the page for AR!
@@ -73,79 +73,79 @@
   </div>
 
   <!--Permission error, microphone + camera, iOS-->
-  <div id="microphonePermissionsErrorApple" class="absolute-fill hidden">
-    <div class='permissionIconIos'>
+  <div id="xrextras-microphone-permissions-error-apple" class="absolute-fill hidden">
+    <div class='xrextras-loading-permission-icon-ios'>
       <img class='foreground-image' src="./camera.svg" />
       <img class='foreground-image' src="./microphone.svg" />
     </div>
-    <p id="microphonePermissionsErrorAppleMessage">
+    <p id="xrextras-microphone-permissions-error-apple-message">
       Reload the page and enable camera + microphone access
     </p>
-    <div class='bottom-message'>
+    <div class='xrextras-loading-bottom-message'>
       Ensure camera + microphone access is allowed in <span class='wk-app-name'></span> app settings
     </div>
   </div>
 
   <!--Permission error, microphone + camera, Android-->
-  <div id="microphonePermissionsErrorAndroid" class="absolute-fill hidden">
-    <div class="permissionIcon">
+  <div id="xrextras-microphone-permissions-error-android" class="absolute-fill hidden">
+    <div class="xrextras-loading-permission-icon">
       <img class='foreground-image' src="./microphone.svg" />
     </div>
-    <div class="loading-error-header">Let's enable your microphone</div>
-    <ol class="loading-error-instructions">
+    <div class="xrextras-loading-error-header">Let's enable your microphone</div>
+    <ol class="xrextras-loading-error-instructions">
       <li>Tap the <img class='foreground-image' src="./dots.svg"> in the top right
       </li>
       <li>Tap Settings</li>
-      <li class="chrome-instruction hidden">
-        <span class="highlight">Site settings</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-highlight">Site settings</span>
       </li>
-      <li class="chrome-instruction hidden">
-        <span class="highlight">Microphone</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-highlight">Microphone</span>
       </li>
-      <li class="chrome-instruction hidden">
-        <span class="highlight">Blocked</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-highlight">Blocked</span>
         <br>
-        <span class="microphone-instruction-block domain-view">apps.8thwall.com</span>
+        <span class="xrextras-loading-microphone-instruction-block xrextras-loading-domain-view">apps.8thwall.com</span>
       </li>
-      <li class="chrome-instruction hidden">
-        <span class="microphone-instruction-button">CLEAR & RESET</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-microphone-instruction-button">CLEAR & RESET</span>
       </li>
-      <li class="chrome-instruction hidden">
-        <span class="highlight">Do the same for Camera</span>
+      <li class="xrextras-loading-chrome-instruction hidden">
+        <span class="xrextras-loading-highlight">Do the same for Camera</span>
       </li>
-      <li class="samsung-instruction hidden">
-        <span class="highlight">Advanced</span>
+      <li class="xrextras-loading-samsung-instruction hidden">
+        <span class="xrextras-loading-highlight">Advanced</span>
       </li>
-      <li class="samsung-instruction hidden">
-        <span class="highlight">Manage website data</span>
+      <li class="xrextras-loading-samsung-instruction hidden">
+        <span class="xrextras-loading-highlight">Manage website data</span>
       </li>
-      <li class="samsung-instruction hidden">
+      <li class="xrextras-loading-samsung-instruction hidden">
         Press and hold<br>
-        <span class="microphone-instruction-block domain-view">apps.8thwall.com</span>
+        <span class="xrextras-loading-microphone-instruction-block xrextras-loading-domain-view">apps.8thwall.com</span>
       </li>
-      <li class="samsung-instruction hidden">
-        <span class="highlight" style="color: #1500ba">DELETE</span>
+      <li class="xrextras-loading-samsung-instruction hidden">
+        <span class="xrextras-loading-highlight" style="color: #1500ba">DELETE</span>
       </li>
     </ol>
-    <div class="loading-error-footer">
+    <div class="xrextras-loading-error-footer">
       <img class='foreground-image' style="transform: rotate(130deg);"
         src="./reload.svg" />
       Then, reload the page for AR!
     </div>
   </div>
 
-  <div id="linkOutViewAndroid" class="absolute-fill hidden">
+  <div id="xrextras-link-out-view-android" class="absolute-fill hidden">
     <div class="error-text-outer-container">
       <div class="error-text-container error-margin-top-5">
         <img id="app_img" class="app-header-img unknown">
         <br />
-        <a id="open_browser_android" class="start-ar-button">Start AR</a>
+        <a id="xrextras-open-browser-android" class="xrextras-loading-start-ar-button">Start AR</a>
         <img class="foreground-image poweredby-img" src="../almosttheremodule/poweredby-horiz-white.svg">
       </div>
     </div>
   </div>
 
-  <div id="copyLinkViewAndroid" class="absolute-fill hidden">
+  <div id="xrextras-copy-link-view-android" class="absolute-fill hidden">
     <div class="error-text-outer-container">
       <div class="error-text-container error-margin-top-5">
         <span id="error_text_header_unknown" class="open-header-unknown">
@@ -154,43 +154,43 @@
         <img id="app_img" class="app-header-img unknown">
         <br />
         <span id="app_link" class="desktop-home-link mobile"></span>
-        <button id="copy_link_android" class="copy-link-btn">Copy Link</button>
+        <button id="xrextras-copy-link-android" class="copy-link-btn">Copy Link</button>
         <img class="foreground-image poweredby-img" src="../almosttheremodule/poweredby-horiz-white.svg">
       </div>
     </div>
   </div>
 
   <!--iOS devicemotion sensor is disabled -->
-  <div id="deviceMotionErrorApple" class="absolute-fill hidden">
-    <div class="loading-error-header">Let's enable your motion sensors</div>
-    <ol class="loading-error-instructions">
+  <div id="xrextras-device-motion-error-apple" class="absolute-fill hidden">
+    <div class="xrextras-loading-error-header">Let's enable your motion sensors</div>
+    <ol class="xrextras-loading-error-instructions">
       <li>Open <img src="./settings-icon-ios.png"
           style="max-height: 4vh"><b>Settings</b></li>
       <li>Select <img src="./safari-icon.png"
           style="max-height: 4vh"><b>Safari</b></li>
-      <li>Enable <span class="highlight">Motion&nbsp;&amp;&nbsp;Orientation Access</span></li>
+      <li>Enable <span class="xrextras-loading-highlight">Motion&nbsp;&amp;&nbsp;Orientation Access</span></li>
       <li>Reload the page <img class="foreground-image" style="transform: rotate(130deg);" src="./reload.svg"></li>
     </ol>
     <!-- Empty footer to take up space -->
-    <div class="loading-error-footer"></div>
+    <div class="xrextras-loading-error-footer"></div>
   </div>
 
-  <div id="userPromptError" class="permission-error absolute-fill hidden">
+  <div id="xrextras-user-prompt-error" class="xrextras-loading-permission-error absolute-fill hidden">
     <h1>Permissions were denied.</h1>
     <p>You need to accept motion permissions to continue.</p>
-    <button id="reloadButton" class="main-button" onClick="window.location.reload()">Refresh</button>
+    <button id="xrextras-reload-button" class="xrextras-loading-main-button" onClick="window.location.reload()">Refresh</button>
   </div>
 
-  <div id="motionPermissionsErrorApple" class="permission-error absolute-fill hidden">
+  <div id="xrextras-motion-permissions-error-apple" class="xrextras-loading-permission-error absolute-fill hidden">
     <h1>Permissions were denied.</h1>
     <p>You've prevented the page from accessing your motion sensors.</p>
     <p>Please close <span class='wk-app-name'></span> app to reenable your motion sensors.</p>
   </div>
 
-  <div id="cameraSelectionWorldTrackingError" class="permission-error absolute-fill hidden">
+  <div id="xrextras-camera-selection-world-tracking-error" class="xrextras-loading-permission-error absolute-fill hidden">
     <p><img height="75px" src="../runtimeerrormodule/computer-voxel.png" class="floater"></p>
     <div class="error-text-header">Oops, something went wrong!</div>
-    <p id="camera_mode_world_tracking_error"></p>
+    <p id="xrextras-camera-mode-world-tracking-error"></p>
   </div>
   <div id='debug-message' style='color:#eee; word-break: break-all; position:absolute; top:0'></div>
 </div>

--- a/packages/xrextras/src/loadingmodule/loading-module.html
+++ b/packages/xrextras/src/loadingmodule/loading-module.html
@@ -1,4 +1,4 @@
-<div id="loadingContainer" class="absolute-fill">
+<div id="xrextras-loading-container" class="absolute-fill">
   <!--Loading screen-->
   <div id="xrextras-load-background" class="absolute-fill">
     <div id="xrextras-load-image-container" class="absolute-fill">

--- a/packages/xrextras/src/loadingmodule/loading-module.js
+++ b/packages/xrextras/src/loadingmodule/loading-module.js
@@ -67,19 +67,30 @@ function create() {
 
   const setRoot = (rootNode) => {
     rootNode_ = rootNode
-    loadBackground_ = rootNode_.querySelector('#loadBackground')
-    loadImageContainer_ = rootNode_.querySelector('#loadImageContainer')
-    camPermissionsRequest_ = document.getElementById('requestingCameraPermissions')
-    camPermissionsFailedAndroid_ = document.getElementById('cameraPermissionsErrorAndroid')
-    camPermissionsFailedApple_ = document.getElementById('cameraPermissionsErrorApple')
-    micPermissionsFailedAndroid_ = document.getElementById('microphonePermissionsErrorAndroid')
-    micPermissionsFailedApple_ = document.getElementById('microphonePermissionsErrorApple')
-    linkOutViewAndroid_ = document.getElementById('linkOutViewAndroid')
-    copyLinkViewAndroid_ = document.getElementById('copyLinkViewAndroid')
-    deviceMotionErrorApple_ = document.getElementById('deviceMotionErrorApple')
-    userPromptError_ = document.getElementById('userPromptError')
-    cameraSelectionError_ = document.getElementById('cameraSelectionWorldTrackingError')
-    motionPermissionsErrorApple_ = document.getElementById('motionPermissionsErrorApple')
+    loadBackground_ = rootNode_.querySelector('#xrextras-load-background')
+    loadImageContainer_ = rootNode_.querySelector('#xrextras-load-image-container')
+    camPermissionsRequest_ =
+      rootNode_.querySelector('#xrextras-requesting-camera-permissions')
+    camPermissionsFailedAndroid_ =
+      rootNode_.querySelector('#xrextras-camera-permissions-error-android')
+    camPermissionsFailedApple_ =
+      rootNode_.querySelector('#xrextras-camera-permissions-error-apple')
+    micPermissionsFailedAndroid_ =
+      rootNode_.querySelector('#xrextras-microphone-permissions-error-android')
+    micPermissionsFailedApple_ =
+      rootNode_.querySelector('#xrextras-microphone-permissions-error-apple')
+    linkOutViewAndroid_ =
+      rootNode_.querySelector('#xrextras-link-out-view-android')
+    copyLinkViewAndroid_ =
+      rootNode_.querySelector('#xrextras-copy-link-view-android')
+    deviceMotionErrorApple_ =
+      rootNode_.querySelector('#xrextras-device-motion-error-apple')
+    userPromptError_ =
+      rootNode_.querySelector('#xrextras-user-prompt-error')
+    cameraSelectionError_ =
+      rootNode_.querySelector('#xrextras-camera-selection-world-tracking-error')
+    motionPermissionsErrorApple_ =
+      rootNode_.querySelector('#xrextras-motion-permissions-error-apple')
   }
 
   const clearRoot = () => {
@@ -115,11 +126,11 @@ function create() {
   // Fade out the loading screen and then hide it.
   const hideLoadingScreen = (removeRoot = true) => {
     if (loadImageContainer_) {
-      loadImageContainer_.classList.add('fade-out')
+      loadImageContainer_.classList.add('xrextras-loading-fade-out')
     }
     setTimeout(() => {
       if (loadBackground_) {
-        loadBackground_.classList.add('fade-out')
+        loadBackground_.classList.add('xrextras-loading-fade-out')
         loadBackground_.style.pointerEvents = 'none'
       }
       setTimeout(() => hideLoadingScreenNow(removeRoot), 400)
@@ -131,7 +142,7 @@ function create() {
   }
 
   const dismissCameraPermissionsPrompt = () => {
-    camPermissionsRequest_.classList.add('fade-out')
+    camPermissionsRequest_.classList.add('xrextras-loading-fade-out')
   }
 
   const promptUserToChangeBrowserSettingsMicrophone = () => {
@@ -139,15 +150,18 @@ function create() {
     if (ua.includes('Linux')) {
       let instructionsToShow
 
-      const domainViews = rootNode_.querySelectorAll('.domain-view')
+      const domainViews =
+        rootNode_.querySelectorAll('.xrextras-loading-domain-view')
       for (let i = 0; i < domainViews.length; i++) {
         domainViews[i].textContent = window.location.hostname
       }
 
       if (navigator.userAgent.includes('SamsungBrowser')) {
-        instructionsToShow = rootNode_.querySelectorAll('.samsung-instruction')
+        instructionsToShow =
+          rootNode_.querySelectorAll('.xrextras-loading-samsung-instruction')
       } else {
-        instructionsToShow = rootNode_.querySelectorAll('.chrome-instruction')
+        instructionsToShow =
+          rootNode_.querySelectorAll('.xrextras-loading-chrome-instruction')
       }
       micPermissionsFailedAndroid_.classList.remove('hidden')
       instructionsToShow.forEach((instruction) => {
@@ -166,15 +180,18 @@ function create() {
     if (ua.includes('Linux')) {
       let instructionsToShow
 
-      const domainViews = rootNode_.querySelectorAll('.domain-view')
+      const domainViews =
+        rootNode_.querySelectorAll('.xrextras-loading-domain-view')
       for (let i = 0; i < domainViews.length; i++) {
         domainViews[i].textContent = window.location.hostname
       }
 
       if (navigator.userAgent.includes('SamsungBrowser')) {
-        instructionsToShow = rootNode_.querySelectorAll('.samsung-instruction')
+        instructionsToShow =
+          rootNode_.querySelectorAll('.xrextras-loading-samsung-instruction')
       } else {
-        instructionsToShow = rootNode_.querySelectorAll('.chrome-instruction')
+        instructionsToShow =
+          rootNode_.querySelectorAll('.xrextras-loading-chrome-instruction')
       }
       camPermissionsFailedAndroid_.classList.remove('hidden')
       instructionsToShow.forEach((instruction) => {
@@ -215,7 +232,7 @@ function create() {
       }
     })
 
-    const cBtn = document.getElementById('open_browser_android')
+    const cBtn = rootNode_.querySelector('#xrextras-open-browser-android')
     const link = window.location.href.replace(/^https:\/\//, '')
     cBtn.href = `intent://${link}#Intent;scheme=https;action=android.intent.action.VIEW;end;`
 
@@ -246,7 +263,7 @@ function create() {
       redirectLinks[i].textContent = link
     }
 
-    const cBtn = document.getElementById('copy_link_android')
+    const cBtn = rootNode_.querySelector('#xrextras-copy-link-android')
     cBtn.addEventListener('click', () => {
       const dummy = document.createElement('input')
       document.body.appendChild(dummy)
@@ -381,7 +398,8 @@ function create() {
       }
       if (status === 'requesting') {
         if (config.verbose) {
-          const debugElement = document.getElementById('camera_mode_world_tracking_error')
+          const debugElement =
+            rootNode_.querySelector('#xrextras-camera-mode-world-tracking-error')
           if (debugElement) {
             debugElement.innerText = JSON.stringify({
               ua,
@@ -477,7 +495,8 @@ function create() {
           if (error.source === 'reality' && error.err === 'slam-front-camera-unsupported') {
             // User is attemping to use Front camera without disabling world tracking
             hideLoadingScreen(false)
-            const errorElement = document.getElementById('camera_mode_world_tracking_error')
+            const errorElement =
+              rootNode_.querySelector('#xrextras-camera-mode-world-tracking-error')
             if (errorElement) {
               errorElement.innerHTML = error.message
               cameraSelectionError_.classList.remove('hidden')

--- a/packages/xrextras/test/css-namespace.test.js
+++ b/packages/xrextras/test/css-namespace.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+const path = require('path')
+
+const cssPath = path.join(__dirname, '../src/loadingmodule/loading-module.css')
+const css = fs.readFileSync(cssPath, 'utf8')
+
+const failures = []
+
+const requiredScopedSelectors = [
+  '#loadingContainer .spin',
+  '#loadingContainer .scale',
+  '#loadingContainer .pulse',
+  '#loadingContainer .fade-out',
+  '#loadingContainer .highlight',
+  '#loadingContainer #loadImage',
+  '#loadingContainer #loadBackground',
+]
+
+for (const selector of requiredScopedSelectors) {
+  if (!css.includes(selector)) {
+    failures.push(`Missing scoped selector: ${selector}`)
+  }
+}
+
+const forbiddenKeyframes = [
+  '@keyframes spin',
+  '@keyframes scale',
+  '@keyframes pulse',
+  '@keyframes fade-out',
+]
+
+for (const keyframe of forbiddenKeyframes) {
+  if (css.includes(keyframe)) {
+    failures.push(`Unscoped keyframe remains: ${keyframe}`)
+  }
+}
+
+const requiredKeyframes = [
+  '@keyframes xrextras-loading-spin',
+  '@keyframes xrextras-loading-scale',
+  '@keyframes xrextras-loading-pulse',
+  '@keyframes xrextras-loading-fade-out',
+]
+
+for (const keyframe of requiredKeyframes) {
+  if (!css.includes(keyframe)) {
+    failures.push(`Missing namespaced keyframe: ${keyframe}`)
+  }
+}
+
+if (failures.length) {
+  process.stderr.write('XRExtras loading CSS namespace regression check failed:\n')
+  failures.forEach(failure => process.stderr.write(`- ${failure}\n`))
+  process.exit(1)
+}
+
+process.stdout.write('XRExtras loading CSS namespace regression check passed\n')

--- a/packages/xrextras/test/css-namespace.test.js
+++ b/packages/xrextras/test/css-namespace.test.js
@@ -1,81 +1,85 @@
 const fs = require('fs')
 const path = require('path')
+const postcss = require('postcss')
+const selectorParser = require('postcss-selector-parser')
 
+const srcDir = path.join(__dirname, '../src')
 const failures = []
 
-const htmlPath = path.join(__dirname, '../src/loadingmodule/loading-module.html')
-const html = fs.readFileSync(htmlPath, 'utf8')
+// CSS files that have not been migrated to the xrextras- namespace yet.
+// Remove a file from this set in the PR that migrates it.
+const skippedCssFiles = new Set([
+  'almosttheremodule/almost-there-module.css',
+  'common.css',
+  'mediarecorder/media-preview.css',
+  'mediarecorder/record-button.css',
+  'pwainstallermodule/pwa-installer-module.css',
+  'runtimeerrormodule/runtime-error-module.css',
+])
 
-const forbiddenDomIds = [
-  'id="loadImage"',
-  'id="loadBackground"',
-]
+const cssFiles = []
 
-for (const id of forbiddenDomIds) {
-  if (html.includes(id)) {
-    failures.push(`Unnamespaced loading DOM id remains: ${id}`)
+const collectCssFiles = (dir) => {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      collectCssFiles(fullPath)
+    } else if (entry.isFile() && entry.name.endsWith('.css')) {
+      cssFiles.push(fullPath)
+    }
   }
 }
 
-const requiredDomIds = [
-  'id="xrextras-load-image"',
-  'id="xrextras-load-background"',
-]
+collectCssFiles(srcDir)
 
-for (const id of requiredDomIds) {
-  if (!html.includes(id)) {
-    failures.push(`Missing namespaced loading DOM id: ${id}`)
+for (const cssPath of cssFiles) {
+  const relativePath = path.relative(srcDir, cssPath).split(path.sep).join('/')
+
+  if (skippedCssFiles.has(relativePath)) {
+    continue
   }
-}
 
-const cssPath = path.join(__dirname, '../src/loadingmodule/loading-module.css')
-const css = fs.readFileSync(cssPath, 'utf8')
+  const css = fs.readFileSync(cssPath, 'utf8')
+  const root = postcss.parse(css, {from: cssPath})
 
-const requiredScopedSelectors = [
-  '#loadingContainer .xrextras-loading-spin',
-  '#loadingContainer .xrextras-loading-scale',
-  '#loadingContainer .xrextras-loading-pulse',
-  '#loadingContainer .xrextras-loading-fade-out',
-  '#loadingContainer .xrextras-loading-highlight',
-  '#loadingContainer #xrextras-load-image',
-  '#loadingContainer #xrextras-load-background',
-]
-for (const selector of requiredScopedSelectors) {
-  if (!css.includes(selector)) {
-    failures.push(`Missing scoped selector: ${selector}`)
-  }
-}
+  root.walkRules((rule) => {
+    selectorParser((selectors) => {
+      selectors.walkIds((node) => {
+        if (!node.value.startsWith('xrextras-')) {
+          failures.push(`${relativePath}: unnamespaced id "#${node.value}"`)
+        }
+      })
 
-const forbiddenKeyframes = [
-  '@keyframes spin',
-  '@keyframes scale',
-  '@keyframes pulse',
-  '@keyframes fade-out',
-]
+      selectors.walkClasses((node) => {
+        if (!node.value.startsWith('xrextras-')) {
+          failures.push(`${relativePath}: unnamespaced class ".${node.value}"`)
+        }
+      })
+    }).processSync(rule.selector)
+  })
 
-for (const keyframe of forbiddenKeyframes) {
-  if (css.includes(keyframe)) {
-    failures.push(`Unscoped keyframe remains: ${keyframe}`)
-  }
-}
+  root.walkAtRules('keyframes', (rule) => {
+    const name = rule.params.trim()
 
-const requiredKeyframes = [
-  '@keyframes xrextras-loading-spin',
-  '@keyframes xrextras-loading-scale',
-  '@keyframes xrextras-loading-pulse',
-  '@keyframes xrextras-loading-fade-out',
-]
+    if (!name.startsWith('xrextras-')) {
+      failures.push(`${relativePath}: unnamespaced keyframes "${name}"`)
+    }
+  })
 
-for (const keyframe of requiredKeyframes) {
-  if (!css.includes(keyframe)) {
-    failures.push(`Missing namespaced keyframe: ${keyframe}`)
-  }
+  root.walkAtRules('-webkit-keyframes', (rule) => {
+    const name = rule.params.trim()
+
+    if (!name.startsWith('xrextras-')) {
+      failures.push(`${relativePath}: unnamespaced keyframes "${name}"`)
+    }
+  })
 }
 
 if (failures.length) {
-  process.stderr.write('XRExtras loading CSS namespace regression check failed:\n')
-  failures.forEach(failure => process.stderr.write(`- ${failure}\n`))
+  process.stderr.write('XRExtras CSS namespace check failed:\n')
+  failures.forEach((failure) => process.stderr.write(`- ${failure}\n`))
   process.exit(1)
 }
 
-process.stdout.write('XRExtras loading CSS namespace regression check passed\n')
+process.stdout.write('XRExtras CSS namespace check passed\n')

--- a/packages/xrextras/test/css-namespace.test.js
+++ b/packages/xrextras/test/css-namespace.test.js
@@ -1,21 +1,45 @@
 const fs = require('fs')
 const path = require('path')
 
+const failures = []
+
+const htmlPath = path.join(__dirname, '../src/loadingmodule/loading-module.html')
+const html = fs.readFileSync(htmlPath, 'utf8')
+
+const forbiddenDomIds = [
+  'id="loadImage"',
+  'id="loadBackground"',
+]
+
+for (const id of forbiddenDomIds) {
+  if (html.includes(id)) {
+    failures.push(`Unnamespaced loading DOM id remains: ${id}`)
+  }
+}
+
+const requiredDomIds = [
+  'id="xrextras-load-image"',
+  'id="xrextras-load-background"',
+]
+
+for (const id of requiredDomIds) {
+  if (!html.includes(id)) {
+    failures.push(`Missing namespaced loading DOM id: ${id}`)
+  }
+}
+
 const cssPath = path.join(__dirname, '../src/loadingmodule/loading-module.css')
 const css = fs.readFileSync(cssPath, 'utf8')
 
-const failures = []
-
 const requiredScopedSelectors = [
-  '#loadingContainer .spin',
-  '#loadingContainer .scale',
-  '#loadingContainer .pulse',
-  '#loadingContainer .fade-out',
-  '#loadingContainer .highlight',
-  '#loadingContainer #loadImage',
-  '#loadingContainer #loadBackground',
+  '#loadingContainer .xrextras-loading-spin',
+  '#loadingContainer .xrextras-loading-scale',
+  '#loadingContainer .xrextras-loading-pulse',
+  '#loadingContainer .xrextras-loading-fade-out',
+  '#loadingContainer .xrextras-loading-highlight',
+  '#loadingContainer #xrextras-load-image',
+  '#loadingContainer #xrextras-load-background',
 ]
-
 for (const selector of requiredScopedSelectors) {
   if (!css.includes(selector)) {
     failures.push(`Missing scoped selector: ${selector}`)


### PR DESCRIPTION
## Summary

Scopes XRExtras loading-module CSS under the existing `#loadingContainer` root to reduce collisions with host application styles.

This also namespaces the loading-module keyframes while preserving the existing selector/class customization surface.

Adds a lightweight regression test to guard the loading CSS namespace.

## Changes

- Scope loading-module selectors under `#loadingContainer`
- Preserve `.xrextras-old-style` compatibility behavior
- Namespace loading keyframes:
  - `xrextras-loading-fade-out`
  - `xrextras-loading-spin`
  - `xrextras-loading-scale`
  - `xrextras-loading-pulse`
- Add a regression check for scoped selectors and keyframes
- Add `npm test` for the namespace check

## Validation

- `npm test`
- `npm run build`
- `./scripts/lint.sh`

Related to #228 and the broader XRExtras 2.0 work discussed in Discussion #255.