### PR TITLE
[xrhome] Improve error reporting flow for the desktop app

### DIFF
--- a/.github/ISSUE_TEMPLATE/desktop-error.yml
+++ b/.github/ISSUE_TEMPLATE/desktop-error.yml
@@ -1,0 +1,57 @@
+name: "Desktop Error Report"
+description: "Something not working in the desktop app?"
+title: "Desktop Error:"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please fill out the following information to the best of your ability. The better the information provided, the quicker we can solve the problem.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: "Check for Duplicates"
+      description: "Please check [open issues](https://github.com/8thwall/8thwall/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug) to see if your issue has already been raised."
+      options:
+        - label: "I didn't find anything."
+          required: true
+    validations:
+      required: true
+  - type: textarea
+    id: describe_the_bug
+    attributes:
+      label: "Describe the Bug"
+      description: "Include as much detail as you like."
+    validations:
+      required: true
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: "Steps to Reproduce"
+      description: "This helps us recreate the issue on our side so we can confirm the fix."
+      placeholder: "1. Go to '...' 2. Click on '...' 3. Scroll down to '...' 4. See error"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environment"
+      description: "Device Type, OS version, desktop app version, or any other details that may be relevant"
+      placeholder: "e.g., M3 Mac, macOS 14.0, Chrome 120, ECS v3.2.1"
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots_logs
+    attributes:
+      label: "Screenshots / Logs"
+      description: "If applicable, add screenshots or log output to help explain the problem."
+      placeholder: "Paste screenshots or logs here..."
+    validations:
+      required: false
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: "Diagnostics"
+      description: "This is pre-filled when reporting issues from the app, feel free to leave it blank."
+    validations:
+      required: false

--- a/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
@@ -33,6 +33,37 @@ interface ICaughtErrorPage {
   error: Error
 }
 
+/* eslint-disable local-rules/hardcoded-copy */
+const generateReportLink = (error: Error) => {
+  const params = new URLSearchParams({template: 'desktop-error.yml'})
+
+  let message: string
+  try {
+    message = error.message
+  } catch (err) {
+    // No message
+  }
+  params.set('title', `Desktop Error: ${message || ''}`)
+
+  let stackTrace: string
+  try {
+    stackTrace = error.stack && String(error.stack)
+  } catch (err) {
+    // No stack trace
+  }
+
+  params.set('diagnostics', `<details><summary>Show</summary>
+
+\`\`\`
+Build ID: ${Build8.VERSION_ID}
+${stackTrace || 'Stack Trace Unavailable'}
+\`\`\`
+</details>`)
+
+  return `https://github.com/8thwall/8thwall/issues/new?${params.toString()}`
+}
+/* eslint-enable local-rules/hardcoded-copy */
+
 const CaughtErrorPage: React.FC<ICaughtErrorPage> = ({error, onReset}) => {
   const {t} = useTranslation(['caught-error-page', 'common'])
 
@@ -54,7 +85,7 @@ const CaughtErrorPage: React.FC<ICaughtErrorPage> = ({error, onReset}) => {
             ns='caught-error-page'
             i18nKey='caught_error_page.open_github_issue'
             components={{
-              1: <StandardLink href='https://8th.io/report-desktop-error' newTab>1</StandardLink>,
+              1: <StandardLink href={generateReportLink(error)} newTab>1</StandardLink>,
             }}
           />
         </p>

--- a/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
@@ -51,7 +51,6 @@ const generateReportLink = (error: Error) => {
   } catch (err) {
     // No stack trace
   }
-
   params.set('diagnostics', `<details><summary>Show</summary>
 
 \`\`\`

--- a/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
+++ b/reality/cloud/xrhome/src/client/desktop/caught-error-page.tsx
@@ -106,4 +106,5 @@ const CaughtErrorPage: React.FC<ICaughtErrorPage> = ({error, onReset}) => {
 
 export {
   CaughtErrorPage,
+  generateReportLink,
 }

--- a/reality/cloud/xrhome/src/client/studio/caught-viewport-error.tsx
+++ b/reality/cloud/xrhome/src/client/studio/caught-viewport-error.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Trans, useTranslation} from 'react-i18next'
 
+import {generateReportLink} from '../desktop/caught-error-page'
 import {ErrorDisplay} from '../ui/components/error-display'
 import {PrimaryButton} from '../ui/components/primary-button'
 import {StandardLink} from '../ui/components/standard-link'
@@ -23,7 +24,7 @@ const CaughtViewportError: React.FC<ICaughtViewportError> = ({onReset, error}) =
           ns='caught-error-page'
           i18nKey='caught_error_page.open_github_issue'
           components={{
-            1: <StandardLink href='https://8th.io/report-desktop-error' newTab>1</StandardLink>,
+            1: <StandardLink href={generateReportLink(error)} newTab>1</StandardLink>,
           }}
         />
       </p>


### PR DESCRIPTION
## Context

Adding some guard rails to the error reporting flow to get better info. 

## Testing

Created a hardcoded crash:

<img width="651" height="93" alt="Screenshot 2026-08-22 at 11 44 21 AM" src="https://github.com/user-attachments/assets/bf8b108e-379f-47cb-966f-5caec1b65d7f" />

On a private repo, set up the same template, pointed the link to it, and got:

<img width="1044" height="202" alt="Screenshot 2026-08-22 at 11 44 08 AM" src="https://github.com/user-attachments/assets/b4eb4f02-701a-4d70-ab1f-8521f53ab76e" />

Diagnostics prefilled:

<img width="1087" height="549" alt="Screenshot 2026-08-22 at 11 43 48 AM" src="https://github.com/user-attachments/assets/a4106848-7e88-48c8-b9c0-318e08afa03b" />
