### PR TITLE
[desktop] Add handling for npm install error

### DIFF
--- a/apps/desktop/app/file-sync/project-handler.ts
+++ b/apps/desktop/app/file-sync/project-handler.ts
@@ -281,6 +281,9 @@ const startWatch = withErrorHandlingResponse(async (req: Request) => {
       }
       return makeJsonResponse({})
     } catch (error: any) {
+      if (error.reason === 'npm-install') {
+        return makeJsonResponse({message: 'NPM installation failed', reason: 'npm-install'}, 500)
+      }
       log.info(`Error starting local server: ${error}`)
       throw makeCodedError(`Failed to start watch server: ${error.message}`, 500)
     }

--- a/apps/desktop/local-server.ts
+++ b/apps/desktop/local-server.ts
@@ -26,7 +26,11 @@ const createLocalServer = async (
   savePath: string
 ): Promise<LocalServer> => {
   dispatchSystemLog({appKey, type: 'log', text: 'Installing packages'})
-  await runInstallCommand(appKey, savePath)
+  try {
+    await runInstallCommand(appKey, savePath)
+  } catch (err: any) {
+    throw Object.assign(err, {reason: 'npm-install'})
+  }
   const [primaryPort, buildPort, dev8SocketPort] = await Promise.all([
     getPort({port: portNumbers(58000, 58999)}),
     getPort({port: portNumbers(59000, 59999)}),

--- a/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
+++ b/reality/cloud/xrhome/src/client/i18n/en-US/cloud-studio-pages.json
@@ -738,6 +738,7 @@
   "recommendation_box.inject_message": "This project is missing a required configuration change in config/webpack.config.js.",
   "recommendation_box.copy_plugin_message": "Asset configuration was mistakenly left out of the project template in config/webpack.config.js.",
   "recommendation_box.dev_socket_message": "To improve device preview, a tweak is recommended to your webpack configuration.",
+  "recommendation_box.npm_install_failed_message": "An error occurred during npm install. Please check network connection. Detailed logs are available in the bottom bar.",
   "recommendation_box.fix": "Apply Fix",
   "recommendation_box.dismiss": "Dismiss",
   "reflection.menu.label.url": "URL",

--- a/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
@@ -29,12 +29,19 @@ type FileSyncStatus =
 | 'listening'  // Listening for local changes
 | 'active'  // Actively syncing files, changes are being processed
 
+type BuildStatus =
+| 'starting'
+| 'npm-install-failed'
+| 'failed'
+| 'running'
+
 type ILocalSyncContext = {
   appKey: string
   localBuildUrl?: string
   localBuildRemoteUrl?: string
   assetVersions: Record<string, string>
   fileSyncStatus: FileSyncStatus
+  buildStatus: BuildStatus
   restartServer: () => Promise<void>
 }
 
@@ -110,6 +117,7 @@ const LocalSyncContextProvider: React.FC<{children: React.ReactNode}> = ({childr
   const git = useCurrentGit()
   const {filesByPath, repo} = git
   const [fileSyncStatus, setFileSyncStatus] = React.useState<FileSyncStatus>('checking')
+  const [buildStatus, setBuildStatus] = React.useState<BuildStatus>('starting')
   const {saveFiles, deleteFile, deleteFiles, createFolder} = useActions(coreGitActions)
   const [localBuildUrl, setLocalBuildUrl] = React.useState<string>('')
   const [localBuildRemoteUrl, setLocalBuildRemoteUrl] = React.useState<string>('')
@@ -347,14 +355,34 @@ const LocalSyncContextProvider: React.FC<{children: React.ReactNode}> = ({childr
     queryClient.invalidateQueries(getProjectConfigStatusQuery(appKey))
   }
 
+  const startBuild = async () => {
+    setBuildStatus('starting')
+    try {
+      await watchLocal(appKey)
+      setBuildStatus('running')
+    } catch (err) {
+      let status: BuildStatus = 'failed'
+      try {
+        const {reason} = await err.res.json()
+        if (reason === 'npm-install') {
+          status = 'npm-install-failed'
+        }
+      } catch (e) {
+        // Unable to extract reason, continue with default reason
+      }
+      setBuildStatus(status)
+      throw err
+    }
+  }
+
   useAbandonableEffect(async (abandon) => {
-    await abandon(watchLocal(appKey))
+    await abandon(startBuild())
     await refreshServerUrls()
   }, [appKey])
 
   const restartServer = async () => {
     await stopWatchLocal(appKey)
-    await watchLocal(appKey)
+    await startBuild()
     await refreshServerUrls()
   }
 
@@ -414,6 +442,7 @@ const LocalSyncContextProvider: React.FC<{children: React.ReactNode}> = ({childr
     localBuildRemoteUrl,
     assetVersions,
     fileSyncStatus,
+    buildStatus,
     restartServer,
   }
 

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -18,7 +18,7 @@ import {TertiaryButton} from '../ui/components/tertiary-button'
 import {StandardModalHeader} from '../ui/components/standard-modal-header'
 import {applyProjectConfigFix} from './local-sync-api'
 import useCurrentApp from '../common/use-current-app'
-import {useLocalSyncContext, useMaybeLocalSyncContext} from './local-sync-context'
+import {useLocalSyncContext} from './local-sync-context'
 import {
   getProjectConfigStatusQuery, useProjectConfigStatusOrLoading,
 } from '../hooks/use-project-config'

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -234,9 +234,6 @@ const RetryInstallRecommendation = () => {
           <BoldButton onClick={async () => localSyncContext.restartServer()}>
             {t('button.try_again', {ns: 'common'})}
           </BoldButton>
-          {/* <BoldButton onClick={() => setDismissed(true)}>
-            {t('recommendation_box.dismiss')}
-          </BoldButton> */}
         </SpaceBetween>
       </SpaceBetween>
     </StaticBanner>

--- a/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
+++ b/reality/cloud/xrhome/src/client/studio/recommendation-box.tsx
@@ -18,7 +18,7 @@ import {TertiaryButton} from '../ui/components/tertiary-button'
 import {StandardModalHeader} from '../ui/components/standard-modal-header'
 import {applyProjectConfigFix} from './local-sync-api'
 import useCurrentApp from '../common/use-current-app'
-import {useLocalSyncContext} from './local-sync-context'
+import {useLocalSyncContext, useMaybeLocalSyncContext} from './local-sync-context'
 import {
   getProjectConfigStatusQuery, useProjectConfigStatusOrLoading,
 } from '../hooks/use-project-config'
@@ -217,12 +217,39 @@ const DevSocketFixRecommendation = () => {
   )
 }
 
+const RetryInstallRecommendation = () => {
+  const {t} = useTranslation(['cloud-studio-pages', 'common'])
+  const localSyncContext = useLocalSyncContext()
+  const visible = localSyncContext.buildStatus === 'npm-install-failed'
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <StaticBanner type='danger'>
+      <SpaceBetween direction='vertical'>
+        {t('recommendation_box.npm_install_failed_message')}
+        <SpaceBetween>
+          <BoldButton onClick={async () => localSyncContext.restartServer()}>
+            {t('button.try_again', {ns: 'common'})}
+          </BoldButton>
+          {/* <BoldButton onClick={() => setDismissed(true)}>
+            {t('recommendation_box.dismiss')}
+          </BoldButton> */}
+        </SpaceBetween>
+      </SpaceBetween>
+    </StaticBanner>
+  )
+}
+
 const RecommendationBox = () => (
   <>
     <AssetBundleRecommendation />
     <WebpackInjectFixRecommendation />
     <CopyPluginFixRecommendation />
     <DevSocketFixRecommendation />
+    <RetryInstallRecommendation />
   </>
 )
 


### PR DESCRIPTION
## Context

This is related to the `Could not load metadata` issue: https://github.com/8thwall/8thwall/issues/258 https://github.com/8thwall/8thwall/issues/250 https://github.com/8thwall/8thwall/issues/145

Taking some of the ideas from https://github.com/8thwall/8thwall/pull/257

## Testing

With:

```
"preinstall": "echo 'rejecting install' && exit 1",
```

<img width="1597" height="950" alt="Screenshot 2026-08-22 at 1 49 34 PM" src="https://github.com/user-attachments/assets/0838eaf6-0a21-4477-9d43-479d0fcaaf7f" />

