### PR TITLE
[xrhome] Prevent useRuntimeMetadata from causing crashes

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
@@ -351,7 +351,10 @@ const LocalSyncContextProvider: React.FC<{children: React.ReactNode}> = ({childr
       setLocalBuildRemoteUrl('')
     }
 
-    queryClient.invalidateQueries(getRuntimeMetadataQuery(appKey))
+    const runtimeQuery = getRuntimeMetadataQuery(appKey)
+    queryClient.cancelQueries(runtimeQuery)
+    queryClient.invalidateQueries(runtimeQuery)
+
     queryClient.invalidateQueries(getProjectConfigStatusQuery(appKey))
   }
 

--- a/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
+++ b/reality/cloud/xrhome/src/client/studio/runtime-version/use-runtime-metadata.ts
@@ -5,21 +5,35 @@ import {getRuntimeMetadata} from '../local-sync-api'
 
 /* eslint-disable no-await-in-loop */
 
+const untilAbort = (signal: AbortSignal) => new Promise<void>((resolve) => {
+  if (signal.aborted) {
+    resolve()
+  } else {
+    signal.addEventListener('abort', () => {
+      resolve()
+    })
+  }
+})
+
 const getRuntimeMetadataQuery = (appKey: string) => ({
   queryKey: ['runtimeMetadata', appKey],
-  queryFn: async () => {
+  queryFn: async ({signal}: {signal: AbortSignal}) => {
     // NOTE(christoph): During first time setup, this may mount before the config is fully
     // initialized. After the server starts, it will trigger a refetch regardless, but to avoid
     // error screens on start, absorb failures.
     let iterations = 0
     while (iterations++ < 10) {
+      if (signal.aborted) {
+        throw new Error('runtimeMetadata cancelled')
+      }
       try {
         return await getRuntimeMetadata(appKey)
       } catch (err) {
         await new Promise(r => setTimeout(r, 1500))
       }
     }
-    throw new Error('Could not load metadata')
+    await untilAbort(signal)
+    throw new Error('runtimeMetadata cancelled after timeout')
   },
 })
 


### PR DESCRIPTION
## Context

This removes the possibility for the `Could not load metadata` issue: https://github.com/8thwall/8thwall/issues/258 https://github.com/8thwall/8thwall/issues/250 https://github.com/8thwall/8thwall/issues/145 to cause a crash. 

Taking some of the ideas from https://github.com/8thwall/8thwall/pull/257

Instead of throwing an error, which crashes the entire screen, we start a promise that doesn't resolve until the fetch is cancelled, so the more self-contained loading states just sit there waiting.

Meanwhile, after a successful launch of the server, we need to cancel that query and refetch, which I expected `cancelRefetch` (true by default) to handle, but it doesn't, see: https://github.com/TanStack/query/issues/6536

Instead, we call `cancelQueries` to make sure that initial fetch is also cancelled.

## Testing

Cancelling cancels initial fetch:

<img width="446" height="477" alt="Screenshot 2026-08-22 at 5 08 52 PM" src="https://github.com/user-attachments/assets/93cc0ffb-da5f-4dfd-945c-08fa3c4520f1" />


After a bad install, there are no crashes, we just stay in the loading state:

<img width="935" height="963" alt="Screenshot 2026-08-22 at 5 21 16 PM" src="https://github.com/user-attachments/assets/b6c8ad61-c0f8-4ceb-8186-be65efc82f50" />


