### PR TITLE
[engine] Honor the disableWorldTracking option in XrController.configure()

### DIFF
--- a/reality/app/xr/js/src/tracking-controller.ts
+++ b/reality/app/xr/js/src/tracking-controller.ts
@@ -200,6 +200,7 @@ const createAuthTokenSubscription = (sccPromise_: Promise<XrTrackingccModule>) =
 }
 
 interface TrackingControllerConfig {
+  disableWorldTracking?: boolean
   enableLighting?: boolean
   imageTargets?: string[]
   imageTargetData?: ImageTargetData[]
@@ -1297,6 +1298,9 @@ const XrControllerFactory = singleton((
   const configure = (args: TrackingControllerConfig) => {
     if (!args) {
       return
+    }
+    if (args.disableWorldTracking !== undefined) {
+      disableWorldTracking_ = !!args.disableWorldTracking
     }
     if (args.enableLighting !== undefined) {
       enableLighting_ = !!args.enableLighting


### PR DESCRIPTION
First of all, thank you for maintaining this project and for opening the engine
up as MIT. Being able to read and build the source is exactly what made it
possible to track this one down.

## Why is this PR needed?

`XrController` keeps a module-level `disableWorldTracking_` flag and reads it in
four places, but `configure()` never assigns it from its argument.

```ts
// src/tracking-controller.ts
let disableWorldTracking_ = false        // L267, declared

const configure = (args: TrackingControllerConfig) => {
  if (!args) { return }
  if (args.enableLighting !== undefined) { ... }      // handled
  if (args.leftHandedAxes !== undefined) { ... }      // handled
  if (args.mirroredDisplay !== undefined) { ... }     // handled
  // args.disableWorldTracking is never read
}
```

So `XR8.XrController.configure({disableWorldTracking: true})` is ignored
**silently**: no error, no warning. `XrControllerConfig` is `type
XrControllerConfig = TODO`, so the call does not fail type checking either, and
there is no way for a caller to detect that the option was dropped.

The failure surfaces later, in `onBeforeSessionInitialize`, as:

```
[XR] Reality with camera on non-mobile devices requires disableWorldTracking
```

The engine asks the caller to set an option that has no reachable setter.

This matters beyond desktop convenience: this engine ships with SLAM removed, so
world tracking cannot run here at all. Disabling it is the only viable
configuration for the open-source build, which makes Image Target tracking
unusable on desktop without patching the engine.

## What does this PR do?

Declares `disableWorldTracking` on `TrackingControllerConfig` and applies it in
`configure()`, following the pattern already used for `enableLighting`,
`leftHandedAxes` and `mirroredDisplay`. Four lines, one file, no behaviour change
for callers that do not pass the option.

## Test plan

**Manual test:** built `//reality/app/xr/js:bundle` with
`--config=wasmreleasesimd`, both with and without this change, and served a
minimal Image Target page in a desktop browser:

```js
XR8.XrController.configure({disableWorldTracking: true, imageTargetData: [target]})
XR8.addCameraPipelineModules([
  XR8.GlTextureRenderer.pipelineModule(),
  XR8.Threejs.pipelineModule(),
  XR8.XrController.pipelineModule(),
  myModule,
])
XR8.run({canvas, allowedDevices: XR8.XrConfig.device().ANY})
```

- **Before:** session initialization throws
  `[XR] Reality with camera on non-mobile devices requires disableWorldTracking`,
  even though the option is passed.
- **After:** the camera starts, `reality.imagefound` / `reality.imageupdated`
  fire, and the target is tracked.

**Unit test:** not added. `src/tracking-controller.ts` has no test file and no
`js_test` target today (the only test targets under `src/` are
`layers-controller-test`, `lifecycle-test`, `pixel-transforms-test` and
`preload-chunks-format-test`), so covering this would mean standing up a new
harness for the module. Happy to add one if you would like it in this PR.

## Notes

- I have not run `./scripts/lint.sh` (it needs a Bazel toolchain I do not have
  set up), but the added block is structurally identical to the `enableLighting`
  block below it and stays well within `max-len`.
- Happy to also add the option to the public `XrControllerConfig` type if you
  would prefer it exposed there rather than only on the internal config
  interface. I left the public API surface untouched to keep the change minimal.