### PR TITLE
[eslint] Fix gitignore resolution when running in a subdirectory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,7 @@ const {default: pluginImport} = await resolve('eslint-plugin-import', 'lib/index
 const {fixupConfigRules} = await resolve('@eslint/compat', 'dist/cjs/index.cjs')
 const {includeIgnoreFile} = await resolve('eslint/config', '../lib/config-api.js')
 
-const ROOT = process.cwd()
+const ROOT = import.meta.dirname
 
 const EXTENSIONS = ['.js', '.ts', '.tsx', '.mjs']
 


### PR DESCRIPTION
## Context

When running vscode within reality/cloud/xrhome:

<img width="1164" height="138" alt="Screenshot 2026-09-09 at 7 36 04 PM" src="https://github.com/user-attachments/assets/86bdc6f9-ea9b-4e3a-b618-6754e3836091" />

## Testing

Works now, as well as through scripts/lint.sh and eslint.sh

