### PR TITLE
[xrhome] Fix null repo during load

### DIFF
--- a/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
+++ b/reality/cloud/xrhome/src/client/studio/local-sync-context.tsx
@@ -266,6 +266,8 @@ const LocalSyncContextProvider: React.FC<{children: React.ReactNode}> = ({childr
     }
   })
 
+  // NOTE(christoph): The effect to initialize the empty git state may not have run yet
+  const canListen = !!repo
   React.useEffect(() => {
     window.electron.fileWatch?.addHandler(appKey, handleLocalSyncMessage)
     setFileSyncStatus('listening')
@@ -273,7 +275,7 @@ const LocalSyncContextProvider: React.FC<{children: React.ReactNode}> = ({childr
     return () => {
       window.electron.fileWatch?.removeHandler(appKey)
     }
-  }, [appKey])
+  }, [canListen, appKey])
 
   const canSyncFiles = fileSyncStatus === 'listening'
   useAbandonableEffect(async (abandon) => {


### PR DESCRIPTION
## Context

Related to https://github.com/8thwall/8thwall/issues/268

## Testing

With a delayed repo load:

<img width="392" height="242" alt="Screenshot 2026-09-09 at 7 33 51 PM" src="https://github.com/user-attachments/assets/d15430f1-956d-4a55-b53c-31675649fe00" />

We see "no repo yet" logged from here

<img width="379" height="211" alt="Screenshot 2026-09-09 at 7 34 05 PM" src="https://github.com/user-attachments/assets/f004be20-5dec-4e3e-88fb-38571550624e" />

In 268, it seems that the 

```
setFileSyncStatus('listening') -> getFileStateSnapshot -> setFileSyncStatus('active') -> FileSyncSuspense -> inner editor mount
``` 

had beaten the `gitRepoAction`, which seems super unlikely, so there might be something else at play.

## Testing

- Studio and Non-studio projects both load properly
- No lint or ts errors
